### PR TITLE
Introduced initializing of fiskaly data if they don't exist

### DIFF
--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/ClientTests.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/ClientTests.cs
@@ -10,24 +10,27 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
         [Test]
         public async Task CreateClientSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var data = await TestFixture.GetFiskalyTestData();
+            var client = data.FiskalyClient;
+            var tssId = data.Tss.Id;
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
 
-            await client.AdminLoginAsync(accessToken, TestFixture.TssId, TestFixture.AdminPin);
-            var createdClient = await client.CreateClientAsync(accessToken, TestFixture.TssId);
+            await client.AdminLoginAsync(accessToken, tssId, TestFixture.AdminPin);
+            var createdClient = await client.CreateClientAsync(accessToken, tssId);
 
             AssertClient(createdClient.IsSuccess, createdClient.SuccessResult.Id);
 
             // Disabling the Client so we don't exceed the test environment limit.
-            await client.UpdateClientAsync(accessToken, TestFixture.TssId, createdClient.SuccessResult.Id, ClientState.Deregistered);
+            await client.UpdateClientAsync(accessToken, tssId, createdClient.SuccessResult.Id, ClientState.Deregistered);
         }
 
         [Test]
         public async Task GetClientSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var data = await TestFixture.GetFiskalyTestData();
+            var client = data.FiskalyClient;
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
-            var result = await client.GetClientAsync(accessToken, TestFixture.ClientId, TestFixture.TssId);
+            var result = await client.GetClientAsync(accessToken, data.Client.Id, data.Tss.Id);
 
             AssertClient(result.IsSuccess, result.SuccessResult.Id);
         }

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/ClientTests.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/ClientTests.cs
@@ -10,7 +10,7 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
         [Test]
         public async Task CreateClientSucceeds()
         {
-            var client = TestFixture.GetFiskalyClient();
+            var client = await TestFixture.GetFiskalyClient();
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
 
             await client.AdminLoginAsync(accessToken, TestFixture.TssId, TestFixture.AdminPin);
@@ -25,7 +25,7 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
         [Test]
         public async Task GetClientSucceeds()
         {
-            var client = TestFixture.GetFiskalyClient();
+            var client = await TestFixture.GetFiskalyClient();
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
             var result = await client.GetClientAsync(accessToken, TestFixture.ClientId, TestFixture.TssId);
 

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/ClientTests.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/ClientTests.cs
@@ -10,7 +10,7 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
         [Test]
         public async Task CreateClientSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var client = TestFixture.GetFiskalyClient();
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
 
             await client.AdminLoginAsync(accessToken, TestFixture.TssId, TestFixture.AdminPin);
@@ -25,7 +25,7 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
         [Test]
         public async Task GetClientSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var client = TestFixture.GetFiskalyClient();
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
             var result = await client.GetClientAsync(accessToken, TestFixture.ClientId, TestFixture.TssId);
 

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/FiskalyTestData.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/FiskalyTestData.cs
@@ -1,0 +1,21 @@
+﻿using Mews.Fiscalizations.Germany.V2;
+using Mews.Fiscalizations.Germany.V2.Model;
+
+namespace Mews.Fiscalizations.Germany.Tests.V2
+{
+    internal class FiskalyTestData
+    {
+        public FiskalyTestData(FiskalyClient fiskalyClient, Tss tss, Client client)
+        {
+            FiskalyClient = fiskalyClient;
+            Tss = tss;
+            Client = client;
+        }
+
+        public FiskalyClient FiskalyClient { get; }
+
+        public Tss Tss { get; }
+
+        public Client Client { get; }
+    }
+}

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TestFixture.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TestFixture.cs
@@ -9,7 +9,7 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
     {
         static TestFixture()
         {
-            InitializeFiskalyData(GetFiskalyClient()).GetAwaiter().GetResult();
+            InitializeFiskalyData(GetFiskalyClient()).ConfigureAwait(continueOnCapturedContext: false).GetAwaiter().GetResult();
         }
 
         public static readonly Guid ClientId = new Guid(Environment.GetEnvironmentVariable("german_client_Id") ?? "INSERT_CLIENT_ID");

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TestFixture.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TestFixture.cs
@@ -1,21 +1,51 @@
 ﻿using Mews.Fiscalizations.Germany.V2;
 using Mews.Fiscalizations.Germany.V2.Model;
 using System;
+using System.Threading.Tasks;
 
 namespace Mews.Fiscalizations.Germany.Tests.V2
 {
     public static class TestFixture
     {
-        public static readonly Guid ClientId = new Guid(Environment.GetEnvironmentVariable("german_client_Id") ?? "INSERT_CLIENT_ID");
-        public static readonly Guid TssId = new Guid(Environment.GetEnvironmentVariable("german_tss_id") ?? "INSERT_TSS_ID");
-        public static readonly ApiKey ApiKey = ApiKey.Create(Environment.GetEnvironmentVariable("german_api_key") ?? "INSERT_API_KEY").Success.Get();
-        public static readonly ApiSecret ApiSecret = ApiSecret.Create(Environment.GetEnvironmentVariable("german_api_secret") ?? "INSERT_API_SECRET").Success.Get();
-        public static readonly string AdminPin = Environment.GetEnvironmentVariable("german_admin_pin") ?? "INSERT_ADMIN_PIN";
+        static TestFixture()
+        {
+            InitializeFiskalyData(GetFiskalyClient()).GetAwaiter().GetResult();
+        }
+
+        public static readonly Guid ClientId = new Guid(Environment.GetEnvironmentVariable("german_client_Id") ?? "1f813cc3-d78d-400c-81a8-fef412970a97");
+        public static readonly Guid TssId = new Guid(Environment.GetEnvironmentVariable("german_tss_id") ?? "17572356-909a-4938-8c1e-7d192f7e2652");
+        public static readonly ApiKey ApiKey = ApiKey.Create(Environment.GetEnvironmentVariable("german_api_key") ?? "test_ezskuqy6q9wp88q3qh4d0c2ze_library-test").Success.Get();
+        public static readonly ApiSecret ApiSecret = ApiSecret.Create(Environment.GetEnvironmentVariable("german_api_secret") ?? "alDXQVEdbt9Luy8LxYvV5Wydd5uEHwCSNheJNQA0shG").Success.Get();
+        public static readonly string AdminPin = Environment.GetEnvironmentVariable("german_admin_pin") ?? "9582571821";
         public static readonly string AdminPuk = Environment.GetEnvironmentVariable("german_admin_puk") ?? "INSERT_ADMIN_PUK";
 
         public static FiskalyClient GetFiskalyClient()
         {
             return new FiskalyClient(ApiKey, ApiSecret);
+        }
+
+        // Fiskaly deletes the test environment data each week, so we should recreate the deleted data for tests.
+        private static async Task InitializeFiskalyData(FiskalyClient fiskalyClient)
+        {
+            var accessToken = (await fiskalyClient.GetAccessTokenAsync()).SuccessResult;
+            var tssExists = (await fiskalyClient.GetTssAsync(accessToken, TssId)).IsSuccess;
+            if (!tssExists)
+            {
+                var tss = (await fiskalyClient.CreateTssAsync(accessToken, TssId)).SuccessResult;
+                await fiskalyClient.UpdateTssAsync(accessToken, TssId, TssState.Uninitialized);
+                await fiskalyClient.ChangeAdminPinAsync(accessToken, TssId, tss.AdminPuk, AdminPin);
+                await fiskalyClient.AdminLoginAsync(accessToken, TssId, AdminPin);
+                await fiskalyClient.UpdateTssAsync(accessToken, TssId, TssState.Initialized);
+                await fiskalyClient.AdminLogoutAsync(TssId);
+            }
+
+            var clientExists = (await fiskalyClient.GetClientAsync(accessToken, ClientId, TssId)).IsSuccess;
+            if (!clientExists)
+            {
+                await fiskalyClient.AdminLoginAsync(accessToken, TssId, AdminPin);
+                await fiskalyClient.CreateClientAsync(accessToken, TssId);
+                await fiskalyClient.AdminLogoutAsync(TssId);
+            }
         }
     }
 }

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TestFixture.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TestFixture.cs
@@ -12,11 +12,11 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
             InitializeFiskalyData(GetFiskalyClient()).GetAwaiter().GetResult();
         }
 
-        public static readonly Guid ClientId = new Guid(Environment.GetEnvironmentVariable("german_client_Id") ?? "1f813cc3-d78d-400c-81a8-fef412970a97");
-        public static readonly Guid TssId = new Guid(Environment.GetEnvironmentVariable("german_tss_id") ?? "17572356-909a-4938-8c1e-7d192f7e2652");
-        public static readonly ApiKey ApiKey = ApiKey.Create(Environment.GetEnvironmentVariable("german_api_key") ?? "test_ezskuqy6q9wp88q3qh4d0c2ze_library-test").Success.Get();
-        public static readonly ApiSecret ApiSecret = ApiSecret.Create(Environment.GetEnvironmentVariable("german_api_secret") ?? "alDXQVEdbt9Luy8LxYvV5Wydd5uEHwCSNheJNQA0shG").Success.Get();
-        public static readonly string AdminPin = Environment.GetEnvironmentVariable("german_admin_pin") ?? "9582571821";
+        public static readonly Guid ClientId = new Guid(Environment.GetEnvironmentVariable("german_client_Id") ?? "INSERT_CLIENT_ID");
+        public static readonly Guid TssId = new Guid(Environment.GetEnvironmentVariable("german_tss_id") ?? "INSERT_TSS_ID");
+        public static readonly ApiKey ApiKey = ApiKey.Create(Environment.GetEnvironmentVariable("german_api_key") ?? "INSERT_API_KEY").Success.Get();
+        public static readonly ApiSecret ApiSecret = ApiSecret.Create(Environment.GetEnvironmentVariable("german_api_secret") ?? "INSERT_API_SECRET").Success.Get();
+        public static readonly string AdminPin = Environment.GetEnvironmentVariable("german_admin_pin") ?? "INSERT_ADMIN_PIN";
         public static readonly string AdminPuk = Environment.GetEnvironmentVariable("german_admin_puk") ?? "INSERT_ADMIN_PUK";
 
         public static FiskalyClient GetFiskalyClient()

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TestFixture.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TestFixture.cs
@@ -1,4 +1,5 @@
-﻿using Mews.Fiscalizations.Germany.V2;
+﻿using FuncSharp;
+using Mews.Fiscalizations.Germany.V2;
 using Mews.Fiscalizations.Germany.V2.Model;
 using System;
 using System.Threading.Tasks;
@@ -7,43 +8,48 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
 {
     public static class TestFixture
     {
-        public static readonly Guid ClientId = new Guid(Environment.GetEnvironmentVariable("german_client_Id") ?? "INSERT_CLIENT_ID");
-        public static readonly Guid TssId = new Guid(Environment.GetEnvironmentVariable("german_tss_id") ?? "INSERT_TSS_ID");
         public static readonly ApiKey ApiKey = ApiKey.Create(Environment.GetEnvironmentVariable("german_api_key") ?? "INSERT_API_KEY").Success.Get();
         public static readonly ApiSecret ApiSecret = ApiSecret.Create(Environment.GetEnvironmentVariable("german_api_secret") ?? "INSERT_API_SECRET").Success.Get();
         public static readonly string AdminPin = Environment.GetEnvironmentVariable("german_admin_pin") ?? "INSERT_ADMIN_PIN";
-        public static readonly string AdminPuk = Environment.GetEnvironmentVariable("german_admin_puk") ?? "INSERT_ADMIN_PUK";
-
-        public static async Task<FiskalyClient> GetFiskalyClient()
-        {
-            var fiskalyClient = new FiskalyClient(ApiKey, ApiSecret);
-            await InitializeFiskalyData(fiskalyClient);
-
-            return fiskalyClient;
-        }
 
         // Fiskaly deletes the test environment data each week, so we should recreate the deleted data for tests.
-        private static async Task InitializeFiskalyData(FiskalyClient fiskalyClient)
+        internal static async Task<FiskalyTestData> GetFiskalyTestData()
         {
+            var fiskalyClient = new FiskalyClient(ApiKey, ApiSecret);
             var accessToken = (await fiskalyClient.GetAccessTokenAsync()).SuccessResult;
-            var tssExists = (await fiskalyClient.GetTssAsync(accessToken, TssId)).IsSuccess;
-            if (!tssExists)
-            {
-                var tss = (await fiskalyClient.CreateTssAsync(accessToken, TssId)).SuccessResult;
-                await fiskalyClient.UpdateTssAsync(accessToken, TssId, TssState.Uninitialized);
-                await fiskalyClient.ChangeAdminPinAsync(accessToken, TssId, tss.AdminPuk, AdminPin);
-                await fiskalyClient.AdminLoginAsync(accessToken, TssId, AdminPin);
-                await fiskalyClient.UpdateTssAsync(accessToken, TssId, TssState.Initialized);
-                await fiskalyClient.AdminLogoutAsync(TssId);
-            }
+            var allTsses = (await fiskalyClient.GetAllTSSsAsync(accessToken)).SuccessResult;
 
-            var clientExists = (await fiskalyClient.GetClientAsync(accessToken, ClientId, TssId)).IsSuccess;
-            if (!clientExists)
-            {
-                await fiskalyClient.AdminLoginAsync(accessToken, TssId, AdminPin);
-                await fiskalyClient.CreateClientAsync(accessToken, TssId);
-                await fiskalyClient.AdminLogoutAsync(TssId);
-            }
+            var firstInitalizedTss = allTsses.TssList.FirstOption(t => t.State == TssState.Initialized);
+            return await firstInitalizedTss.Match(
+                async t =>
+                {
+                    var allClients = (await fiskalyClient.GetAllTssClientsAsync(accessToken, t.Id)).SuccessResult;
+                    var firstRegisteredClient = allClients.Clients.FirstOption(c => c.State == ClientState.Registered);
+                    var client = await firstRegisteredClient.Match(
+                        c => Task.FromResult(c),
+                        async _ =>
+                        {
+                            await fiskalyClient.AdminLoginAsync(accessToken, t.Id, AdminPin);
+                            return (await fiskalyClient.CreateClientAsync(accessToken, t.Id)).SuccessResult;
+                        }
+                    );
+                    return new FiskalyTestData(fiskalyClient, t, client);
+                },
+                async _ =>
+                {
+                    var tssId = Guid.NewGuid();
+                    var tss = (await fiskalyClient.CreateTssAsync(accessToken, tssId)).SuccessResult;
+                    await fiskalyClient.UpdateTssAsync(accessToken, tssId, TssState.Uninitialized);
+                    await fiskalyClient.ChangeAdminPinAsync(accessToken, tssId, tss.AdminPuk, AdminPin);
+                    await fiskalyClient.AdminLoginAsync(accessToken, tssId, AdminPin);
+                    await fiskalyClient.UpdateTssAsync(accessToken, tssId, TssState.Initialized);
+                    
+                    var client = (await fiskalyClient.CreateClientAsync(accessToken, tssId)).SuccessResult;
+                    await fiskalyClient.AdminLogoutAsync(tssId);
+
+                    return new FiskalyTestData(fiskalyClient, tss, client);
+                }
+            );
         }
     }
 }

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TestFixture.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TestFixture.cs
@@ -7,11 +7,6 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
 {
     public static class TestFixture
     {
-        static TestFixture()
-        {
-            InitializeFiskalyData(GetFiskalyClient()).ConfigureAwait(continueOnCapturedContext: false).GetAwaiter().GetResult();
-        }
-
         public static readonly Guid ClientId = new Guid(Environment.GetEnvironmentVariable("german_client_Id") ?? "INSERT_CLIENT_ID");
         public static readonly Guid TssId = new Guid(Environment.GetEnvironmentVariable("german_tss_id") ?? "INSERT_TSS_ID");
         public static readonly ApiKey ApiKey = ApiKey.Create(Environment.GetEnvironmentVariable("german_api_key") ?? "INSERT_API_KEY").Success.Get();
@@ -19,9 +14,12 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
         public static readonly string AdminPin = Environment.GetEnvironmentVariable("german_admin_pin") ?? "INSERT_ADMIN_PIN";
         public static readonly string AdminPuk = Environment.GetEnvironmentVariable("german_admin_puk") ?? "INSERT_ADMIN_PUK";
 
-        public static FiskalyClient GetFiskalyClient()
+        public static async Task<FiskalyClient> GetFiskalyClient()
         {
-            return new FiskalyClient(ApiKey, ApiSecret);
+            var fiskalyClient = new FiskalyClient(ApiKey, ApiSecret);
+            await InitializeFiskalyData(fiskalyClient);
+
+            return fiskalyClient;
         }
 
         // Fiskaly deletes the test environment data each week, so we should recreate the deleted data for tests.

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TestFixture.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TestFixture.cs
@@ -37,15 +37,14 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
                 },
                 async _ =>
                 {
-                    var tssId = Guid.NewGuid();
-                    var tss = (await fiskalyClient.CreateTssAsync(accessToken, tssId)).SuccessResult;
-                    await fiskalyClient.UpdateTssAsync(accessToken, tssId, TssState.Uninitialized);
-                    await fiskalyClient.ChangeAdminPinAsync(accessToken, tssId, tss.AdminPuk, AdminPin);
-                    await fiskalyClient.AdminLoginAsync(accessToken, tssId, AdminPin);
-                    await fiskalyClient.UpdateTssAsync(accessToken, tssId, TssState.Initialized);
+                    var tss = (await fiskalyClient.CreateTssAsync(accessToken)).SuccessResult;
+                    await fiskalyClient.UpdateTssAsync(accessToken, tss.Id, TssState.Uninitialized);
+                    await fiskalyClient.ChangeAdminPinAsync(accessToken, tss.Id, tss.AdminPuk, AdminPin);
+                    await fiskalyClient.AdminLoginAsync(accessToken, tss.Id, AdminPin);
+                    await fiskalyClient.UpdateTssAsync(accessToken, tss.Id, TssState.Initialized);
                     
-                    var client = (await fiskalyClient.CreateClientAsync(accessToken, tssId)).SuccessResult;
-                    await fiskalyClient.AdminLogoutAsync(tssId);
+                    var client = (await fiskalyClient.CreateClientAsync(accessToken, tss.Id)).SuccessResult;
+                    await fiskalyClient.AdminLogoutAsync(tss.Id);
 
                     return new FiskalyTestData(fiskalyClient, tss, client);
                 }

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TransactionTests.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TransactionTests.cs
@@ -13,7 +13,7 @@ namespace Mews.Fiscalizations.German.Tests.V2
         [Test]
         public async Task StatusCheckSucceeds()
         {
-            var client = TestFixture.GetFiskalyClient();
+            var client = await TestFixture.GetFiskalyClient();
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
             var status = await client.GetClientAsync(accessToken, TestFixture.ClientId, TestFixture.TssId);
 
@@ -23,7 +23,7 @@ namespace Mews.Fiscalizations.German.Tests.V2
         [Test, Order(1)]
         public async Task GetTransactionSucceeds()
         {
-            var client = TestFixture.GetFiskalyClient();
+            var client = await TestFixture.GetFiskalyClient();
             var accessToken = await client.GetAccessTokenAsync();
             var startedTransaction = await client.StartTransactionAsync(accessToken.SuccessResult, TestFixture.ClientId, TestFixture.TssId, Guid.NewGuid());
             var retrievedStartedTransaction = await client.GetTransactionAsync(accessToken.SuccessResult, TestFixture.TssId, startedTransaction.SuccessResult.Id);
@@ -37,7 +37,7 @@ namespace Mews.Fiscalizations.German.Tests.V2
         [Test, Order(2)]
         public async Task StartTransactionSucceeds()
         {
-            var client = TestFixture.GetFiskalyClient();
+            var client = await TestFixture.GetFiskalyClient();
             var accessToken = await client.GetAccessTokenAsync();
             var startedTransaction = await client.StartTransactionAsync(accessToken.SuccessResult, TestFixture.ClientId, TestFixture.TssId, Guid.NewGuid());
             var successResult = startedTransaction.SuccessResult;
@@ -50,7 +50,7 @@ namespace Mews.Fiscalizations.German.Tests.V2
         [Test, Order(3)]
         public async Task StartAndFinishTransactionSucceeds()
         {
-            var client = TestFixture.GetFiskalyClient();
+            var client = await TestFixture.GetFiskalyClient();
             var clientId = TestFixture.ClientId;
             var tssId = TestFixture.TssId;
             var accessToken = await client.GetAccessTokenAsync();

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TransactionTests.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TransactionTests.cs
@@ -13,7 +13,7 @@ namespace Mews.Fiscalizations.German.Tests.V2
         [Test]
         public async Task StatusCheckSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var client = TestFixture.GetFiskalyClient();
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
             var status = await client.GetClientAsync(accessToken, TestFixture.ClientId, TestFixture.TssId);
 
@@ -23,7 +23,7 @@ namespace Mews.Fiscalizations.German.Tests.V2
         [Test, Order(1)]
         public async Task GetTransactionSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var client = TestFixture.GetFiskalyClient();
             var accessToken = await client.GetAccessTokenAsync();
             var startedTransaction = await client.StartTransactionAsync(accessToken.SuccessResult, TestFixture.ClientId, TestFixture.TssId, Guid.NewGuid());
             var retrievedStartedTransaction = await client.GetTransactionAsync(accessToken.SuccessResult, TestFixture.TssId, startedTransaction.SuccessResult.Id);
@@ -37,7 +37,7 @@ namespace Mews.Fiscalizations.German.Tests.V2
         [Test, Order(2)]
         public async Task StartTransactionSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var client = TestFixture.GetFiskalyClient();
             var accessToken = await client.GetAccessTokenAsync();
             var startedTransaction = await client.StartTransactionAsync(accessToken.SuccessResult, TestFixture.ClientId, TestFixture.TssId, Guid.NewGuid());
             var successResult = startedTransaction.SuccessResult;
@@ -50,7 +50,7 @@ namespace Mews.Fiscalizations.German.Tests.V2
         [Test, Order(3)]
         public async Task StartAndFinishTransactionSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var client = TestFixture.GetFiskalyClient();
             var clientId = TestFixture.ClientId;
             var tssId = TestFixture.TssId;
             var accessToken = await client.GetAccessTokenAsync();

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TransactionTests.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TransactionTests.cs
@@ -13,9 +13,10 @@ namespace Mews.Fiscalizations.German.Tests.V2
         [Test]
         public async Task StatusCheckSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var data = await TestFixture.GetFiskalyTestData();
+            var client = data.FiskalyClient;
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
-            var status = await client.GetClientAsync(accessToken, TestFixture.ClientId, TestFixture.TssId);
+            var status = await client.GetClientAsync(accessToken, data.Client.Id, data.Tss.Id);
 
             Assert.IsTrue(status.IsSuccess);
         }
@@ -23,23 +24,27 @@ namespace Mews.Fiscalizations.German.Tests.V2
         [Test, Order(1)]
         public async Task GetTransactionSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var data = await TestFixture.GetFiskalyTestData();
+            var client = data.FiskalyClient;
+            var tssId = data.Tss.Id;
+            var clientId = data.Client.Id;
             var accessToken = await client.GetAccessTokenAsync();
-            var startedTransaction = await client.StartTransactionAsync(accessToken.SuccessResult, TestFixture.ClientId, TestFixture.TssId, Guid.NewGuid());
-            var retrievedStartedTransaction = await client.GetTransactionAsync(accessToken.SuccessResult, TestFixture.TssId, startedTransaction.SuccessResult.Id);
+            var startedTransaction = await client.StartTransactionAsync(accessToken.SuccessResult, clientId, tssId, Guid.NewGuid());
+            var retrievedStartedTransaction = await client.GetTransactionAsync(accessToken.SuccessResult, tssId, startedTransaction.SuccessResult.Id);
             Assert.AreEqual(retrievedStartedTransaction.SuccessResult.State, TransactionState.Active);
 
-            var finishedTransaction = await client.FinishTransactionAsync(accessToken.SuccessResult, TestFixture.ClientId, TestFixture.TssId, GetBill(), startedTransaction.SuccessResult.Id);
-            var retrievedFinishedTransaction = await client.GetTransactionAsync(accessToken.SuccessResult, TestFixture.TssId, finishedTransaction.SuccessResult.Id);
+            var finishedTransaction = await client.FinishTransactionAsync(accessToken.SuccessResult, clientId, tssId, GetBill(), startedTransaction.SuccessResult.Id);
+            var retrievedFinishedTransaction = await client.GetTransactionAsync(accessToken.SuccessResult, tssId, finishedTransaction.SuccessResult.Id);
             Assert.AreEqual(retrievedFinishedTransaction.SuccessResult.State, TransactionState.Finished);
         }
 
         [Test, Order(2)]
         public async Task StartTransactionSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var data = await TestFixture.GetFiskalyTestData();
+            var client = data.FiskalyClient;
             var accessToken = await client.GetAccessTokenAsync();
-            var startedTransaction = await client.StartTransactionAsync(accessToken.SuccessResult, TestFixture.ClientId, TestFixture.TssId, Guid.NewGuid());
+            var startedTransaction = await client.StartTransactionAsync(accessToken.SuccessResult, data.Client.Id, data.Tss.Id, Guid.NewGuid());
             var successResult = startedTransaction.SuccessResult;
 
             Assert.IsTrue(startedTransaction.IsSuccess);
@@ -50,9 +55,10 @@ namespace Mews.Fiscalizations.German.Tests.V2
         [Test, Order(3)]
         public async Task StartAndFinishTransactionSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
-            var clientId = TestFixture.ClientId;
-            var tssId = TestFixture.TssId;
+            var data = await TestFixture.GetFiskalyTestData();
+            var client = data.FiskalyClient;
+            var clientId = data.Client.Id;
+            var tssId = data.Tss.Id;
             var accessToken = await client.GetAccessTokenAsync();
             var successAccessTokenResult = accessToken.SuccessResult;
             var startedTransaction = await client.StartTransactionAsync(successAccessTokenResult, clientId, tssId, Guid.NewGuid());

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TssTests.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TssTests.cs
@@ -10,7 +10,7 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
         [Test]
         public async Task CreateTssSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var client = TestFixture.GetFiskalyClient();
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
             var createdTss = await client.CreateTssAsync(accessToken);
 
@@ -34,7 +34,7 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
         [Test]
         public async Task GetTssSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var client = TestFixture.GetFiskalyClient();
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
             var tss = await client.GetTssAsync(accessToken, TestFixture.TssId);
 

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TssTests.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TssTests.cs
@@ -10,7 +10,7 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
         [Test]
         public async Task CreateTssSucceeds()
         {
-            var client = TestFixture.GetFiskalyClient();
+            var client = await TestFixture.GetFiskalyClient();
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
             var createdTss = await client.CreateTssAsync(accessToken);
 
@@ -34,7 +34,7 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
         [Test]
         public async Task GetTssSucceeds()
         {
-            var client = TestFixture.GetFiskalyClient();
+            var client = await TestFixture.GetFiskalyClient();
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
             var tss = await client.GetTssAsync(accessToken, TestFixture.TssId);
 

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TssTests.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/TssTests.cs
@@ -10,7 +10,7 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
         [Test]
         public async Task CreateTssSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var client = (await TestFixture.GetFiskalyTestData()).FiskalyClient;
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
             var createdTss = await client.CreateTssAsync(accessToken);
 
@@ -34,9 +34,10 @@ namespace Mews.Fiscalizations.Germany.Tests.V2
         [Test]
         public async Task GetTssSucceeds()
         {
-            var client = await TestFixture.GetFiskalyClient();
+            var data = await TestFixture.GetFiskalyTestData();
+            var client = data.FiskalyClient;
             var accessToken = (await client.GetAccessTokenAsync()).SuccessResult;
-            var tss = await client.GetTssAsync(accessToken, TestFixture.TssId);
+            var tss = await client.GetTssAsync(accessToken, data.Tss.Id);
 
             AssertTss(tss.IsSuccess, tss.SuccessResult.Id);
         }

--- a/src/Germany/Mews.Fiscalizations.Germany/V2/Dto/MultipleClientResponse.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany/V2/Dto/MultipleClientResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Mews.Fiscalizations.Germany.V2.Dto
+{
+    internal class MultipleClientResponse
+    {
+        [JsonProperty("data")]
+        public IEnumerable<ClientResponse> Clients { get; set; }
+    }
+}

--- a/src/Germany/Mews.Fiscalizations.Germany/V2/Dto/MultipleTssResponse.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany/V2/Dto/MultipleTssResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Mews.Fiscalizations.Germany.V2.Dto
+{
+    internal sealed class MultipleTssResponse
+    {
+        [JsonProperty("data")]
+        public IEnumerable<TssResponse> TssList { get; set; }
+    }
+}

--- a/src/Germany/Mews.Fiscalizations.Germany/V2/Dto/TssState.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany/V2/Dto/TssState.cs
@@ -5,6 +5,7 @@
         CREATED,
         UNINITIALIZED,
         INITIALIZED,
-        DISABLED
+        DISABLED,
+        DELETED
     }
 }

--- a/src/Germany/Mews.Fiscalizations.Germany/V2/FiskalyClient.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany/V2/FiskalyClient.cs
@@ -1,6 +1,8 @@
 ﻿using FuncSharp;
 using Mews.Fiscalizations.Germany.V2.Model;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -57,6 +59,24 @@ namespace Mews.Fiscalizations.Germany.V2
             return Client.GetResponseAsync<Dto.TssResponse, Tss>(
                 endpoint: $"tss/{tssId}",
                 successFunc: response => ModelMapper.MapTss(response),
+                token: token
+            );
+        }
+
+        public Task<ResponseResult<MultipleTss>> GetAllTSSsAsync(AccessToken token)
+        {
+            return Client.GetResponseAsync<Dto.MultipleTssResponse, MultipleTss>(
+                endpoint: $"tss",
+                successFunc: response => ModelMapper.MapTSSs(response),
+                token: token
+            );
+        }
+
+        public Task<ResponseResult<MultipleClient>> GetAllTssClientsAsync(AccessToken token, Guid tssId)
+        {
+            return Client.GetResponseAsync<Dto.MultipleClientResponse, MultipleClient>(
+                endpoint: $"/tss/{tssId}/client",
+                successFunc: response => ModelMapper.MapClients(response),
                 token: token
             );
         }

--- a/src/Germany/Mews.Fiscalizations.Germany/V2/FiskalyClient.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany/V2/FiskalyClient.cs
@@ -75,7 +75,7 @@ namespace Mews.Fiscalizations.Germany.V2
         public Task<ResponseResult<MultipleClient>> GetAllTssClientsAsync(AccessToken token, Guid tssId)
         {
             return Client.GetResponseAsync<Dto.MultipleClientResponse, MultipleClient>(
-                endpoint: $"/tss/{tssId}/client",
+                endpoint: $"tss/{tssId}/client",
                 successFunc: response => ModelMapper.MapClients(response),
                 token: token
             );

--- a/src/Germany/Mews.Fiscalizations.Germany/V2/Model/MultipleClient.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany/V2/Model/MultipleClient.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace Mews.Fiscalizations.Germany.V2.Model
+{
+    public sealed class MultipleClient
+    {
+        public MultipleClient(IEnumerable<Client> clients)
+        {
+            Clients = clients;
+        }
+
+        public IEnumerable<Client> Clients { get; }
+    }
+}

--- a/src/Germany/Mews.Fiscalizations.Germany/V2/Model/MultipleTss.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany/V2/Model/MultipleTss.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace Mews.Fiscalizations.Germany.V2.Model
+{
+    public sealed class MultipleTss
+    {
+        public MultipleTss(IEnumerable<Tss> tssList)
+        {
+            TssList = tssList;
+        }
+
+        public IEnumerable<Tss> TssList { get; }
+    }
+}

--- a/src/Germany/Mews.Fiscalizations.Germany/V2/Model/TssState.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany/V2/Model/TssState.cs
@@ -5,6 +5,7 @@
         Created,
         Uninitialized,
         Initialized,
-        Disabled
+        Disabled,
+        Deleted
     }
 }

--- a/src/Germany/Mews.Fiscalizations.Germany/V2/ModelMapper.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany/V2/ModelMapper.cs
@@ -104,6 +104,7 @@ namespace Mews.Fiscalizations.Germany.V2
                 Dto.TssState.DISABLED, _ => TssState.Disabled,
                 Dto.TssState.INITIALIZED, _ => TssState.Initialized,
                 Dto.TssState.UNINITIALIZED, _ => TssState.Uninitialized,
+                Dto.TssState.DELETED, _ => TssState.Deleted,
                 _ => throw new NotImplementedException($"Tss state: {state} is not implemented.")
             );
         }

--- a/src/Germany/Mews.Fiscalizations.Germany/V2/ModelMapper.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany/V2/ModelMapper.cs
@@ -2,6 +2,7 @@
 using Mews.Fiscalizations.Germany.V2.Model;
 using Mews.Fiscalizations.Germany.Utils;
 using System;
+using System.Linq;
 
 namespace Mews.Fiscalizations.Germany.V2
 {
@@ -49,31 +50,22 @@ namespace Mews.Fiscalizations.Germany.V2
 
         internal static ResponseResult<Model.Client> MapClient(Dto.ClientResponse client)
         {
-            return new ResponseResult<Model.Client>(successResult: new Model.Client(
-                serialNumber: client.SerialNumber,
-                created: client.TimeCreation.FromUnixTime(),
-                state: MapClientState(client.State),
-                tssId: client.TssId,
-                id: client.Id
-            ));
+            return new ResponseResult<Model.Client>(successResult: GetClient(client));
         }
 
         internal static ResponseResult<Tss> MapTss(Dto.TssResponse tss)
         {
-            return new ResponseResult<Tss>(successResult: new Tss(
-                id: tss.Id,
-                description: tss.Description,
-                state: MapTssState(tss.State),
-                createdUtc: tss.TimeCreation.FromUnixTime(),
-                initializedUtc: tss.TimeInit.FromUnixTime(),
-                disabledUtc: tss.TimeDisable.FromUnixTime(),
-                certificate: tss.Certificate,
-                serialNumber: tss.SerialNumber,
-                publicKey: tss.PublicKey,
-                signatureCounter: tss.SignatureCounter,
-                signatureAlgorithm: tss.SignatureAlgorithm,
-                transactionCounter: tss.TransactionCounter
-            ));
+            return new ResponseResult<Tss>(successResult: GetTss(tss));
+        }
+
+        internal static ResponseResult<MultipleTss> MapTSSs(Dto.MultipleTssResponse response)
+        {
+            return new ResponseResult<MultipleTss>(successResult: new MultipleTss(response.TssList.Select(t => GetTss(t))));
+        }
+
+        internal static ResponseResult<MultipleClient> MapClients(Dto.MultipleClientResponse response)
+        {
+            return new ResponseResult<MultipleClient>(successResult: new MultipleClient(response.Clients.Select(c => GetClient(c))));
         }
 
         internal static ResponseResult<CreateTssResult> MapCreateTss(Dto.CreateTssResponse createTssResponse)
@@ -95,6 +87,35 @@ namespace Mews.Fiscalizations.Germany.V2
                     transactionCounter: createTssResponse.TransactionCounter
                 )
             ));
+        }
+
+        private static Tss GetTss(Dto.TssResponse tss)
+        {
+            return new Tss(
+                id: tss.Id,
+                description: tss.Description,
+                state: MapTssState(tss.State),
+                createdUtc: tss.TimeCreation.FromUnixTime(),
+                initializedUtc: tss.TimeInit.FromUnixTime(),
+                disabledUtc: tss.TimeDisable.FromUnixTime(),
+                certificate: tss.Certificate,
+                serialNumber: tss.SerialNumber,
+                publicKey: tss.PublicKey,
+                signatureCounter: tss.SignatureCounter,
+                signatureAlgorithm: tss.SignatureAlgorithm,
+                transactionCounter: tss.TransactionCounter
+            );
+        }
+
+        private static Model.Client GetClient(Dto.ClientResponse client)
+        {
+            return new Model.Client(
+                serialNumber: client.SerialNumber,
+                created: client.TimeCreation.FromUnixTime(),
+                state: MapClientState(client.State),
+                tssId: client.TssId,
+                id: client.Id
+            );
         }
 
         private static TssState MapTssState(Dto.TssState state)


### PR DESCRIPTION
## Description

Fiskaly removes Tss and client data from the test environment each week, so we should check if the data exists, we use it, if not we create it again.

## Type of change
- [x] Bug fix.
- [ ] Feature.
- [ ] Consolidation.

## Checklist
- [ ] Is breaking change.
- [ ] Documentation updated.
- [ ] Tests included (please specify cases).
