### PR TITLE
Introduce soap action error handling, part 2

### DIFF
--- a/src/Spain/Mews.Fiscalizations.Spain.Tests/Basics.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain.Tests/Basics.cs
@@ -30,7 +30,6 @@ namespace Mews.Fiscalizations.Spain.Tests.IssuedInvoices
             taxpayerIdentificationNumber: TaxpayerIdentificationNumber.Create(Countries.Spain, System.Environment.GetEnvironmentVariable("spanish_receiver_tax_number") ?? "INSERT_RECEIVER_TAX_NUMBER").Success.Get()
         );
 
-        [Test]
         public async Task CheckNif()
         {
             var goodEntries = NonEmptyEnumerable.Create(
@@ -54,7 +53,6 @@ namespace Mews.Fiscalizations.Spain.Tests.IssuedInvoices
             await AssertNifLookup(serverModifiedEntry.ToEnumerable(), NifSearchResult.NotFoundBecauseNifModifiedByServer);
         }
 
-        [Test]
         public async Task PostInvoice()
         {
             await SuccessfullyPostInvoice(Client);

--- a/src/Spain/Mews.Fiscalizations.Spain.Tests/Basics.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain.Tests/Basics.cs
@@ -30,6 +30,7 @@ namespace Mews.Fiscalizations.Spain.Tests.IssuedInvoices
             taxpayerIdentificationNumber: TaxpayerIdentificationNumber.Create(Countries.Spain, System.Environment.GetEnvironmentVariable("spanish_receiver_tax_number") ?? "INSERT_RECEIVER_TAX_NUMBER").Success.Get()
         );
 
+        [Test]
         public async Task CheckNif()
         {
             var goodEntries = NonEmptyEnumerable.Create(
@@ -53,6 +54,7 @@ namespace Mews.Fiscalizations.Spain.Tests.IssuedInvoices
             await AssertNifLookup(serverModifiedEntry.ToEnumerable(), NifSearchResult.NotFoundBecauseNifModifiedByServer);
         }
 
+        [Test]
         public async Task PostInvoice()
         {
             await SuccessfullyPostInvoice(Client);

--- a/src/Spain/Mews.Fiscalizations.Spain.Tests/Basics.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain.Tests/Basics.cs
@@ -70,9 +70,9 @@ namespace Mews.Fiscalizations.Spain.Tests.IssuedInvoices
 
             var response = await client.SubmitSimplifiedInvoiceAsync(model);
 
-            var responseErrorMessages = response.Invoices.Select(i => i.ErrorMessage).Flatten();
+            var responseErrorMessages = response.SuccessResult.Invoices.Select(i => i.ErrorMessage).Flatten();
             var errorMessage = String.Join(System.Environment.NewLine, responseErrorMessages);
-            Assert.AreEqual(response.Result, RegisterResult.Correct, errorMessage);
+            Assert.AreEqual(response.SuccessResult.Result, RegisterResult.Correct, errorMessage);
 
             return invoice;
         }
@@ -82,8 +82,8 @@ namespace Mews.Fiscalizations.Spain.Tests.IssuedInvoices
             var validator = new NifValidator(Certificate, httpTimeout: TimeSpan.FromSeconds(30));
             var response = await validator.CheckNif(new Request(entries));
 
-            Assert.AreEqual(response.Results.Count(), entries.Count());
-            foreach (var result in response.Results)
+            Assert.AreEqual(response.SuccessResult.Results.Count(), entries.Count());
+            foreach (var result in response.SuccessResult.Results)
             {
                 Assert.AreEqual(expectedResult, result.Result);
             }

--- a/src/Spain/Mews.Fiscalizations.Spain.Tests/SoapClientTests.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain.Tests/SoapClientTests.cs
@@ -44,8 +44,15 @@ namespace Mews.Fiscalizations.Spain.Tests
         [Test]
         public async Task InvalidSoapActionShouldFail()
         {
-            await soapClient.SendAsync<InvalidSoapMessage, SomeSoapResponse>(new InvalidSoapMessage { Message = "bla-bla-bla" });
-            Assert.Pass();
+            try
+            {
+                await soapClient.SendAsync<InvalidSoapMessage, SomeSoapResponse>(new InvalidSoapMessage { Message = "bla-bla-bla" });
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+            Assert.Fail("Test was suppose to fail");
         }
     }
 }

--- a/src/Spain/Mews.Fiscalizations.Spain.Tests/SoapClientTests.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain.Tests/SoapClientTests.cs
@@ -44,15 +44,8 @@ namespace Mews.Fiscalizations.Spain.Tests
         [Test]
         public async Task InvalidSoapActionShouldFail()
         {
-            try
-            {
-                await soapClient.SendAsync<InvalidSoapMessage, SomeSoapResponse>(new InvalidSoapMessage { Message = "bla-bla-bla" });
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
-            Assert.Fail("Test was suppose to fail");
+            await soapClient.SendAsync<InvalidSoapMessage, SomeSoapResponse>(new InvalidSoapMessage { Message = "bla-bla-bla" });
+            Assert.Pass();
         }
     }
 }

--- a/src/Spain/Mews.Fiscalizations.Spain.Tests/SoapClientTests.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain.Tests/SoapClientTests.cs
@@ -1,10 +1,8 @@
 ﻿using Mews.Fiscalizations.Spain.Communication;
+using Mews.Fiscalizations.Spain.Dto.Responses;
 using Mews.Fiscalizations.Spain.Tests.IssuedInvoices;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 
@@ -44,15 +42,10 @@ namespace Mews.Fiscalizations.Spain.Tests
         [Test]
         public async Task InvalidSoapActionShouldFail()
         {
-            try
-            {
-                await soapClient.SendAsync<InvalidSoapMessage, SomeSoapResponse>(new InvalidSoapMessage { Message = "bla-bla-bla" });
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-            }
-            Assert.Fail("Test was suppose to fail");
+            var soapFault = await soapClient.SendAsync<InvalidSoapMessage, SubmitIssuedInvoicesResponse>(new InvalidSoapMessage { Message = "bla-bla-bla" });
+            Assert.IsFalse(soapFault.IsSuccess);
+            throw new Exception($"{soapFault.ErrorResult.Code} >> {soapFault.ErrorResult.Message}");
+
         }
     }
 }

--- a/src/Spain/Mews.Fiscalizations.Spain.Tests/SoapClientTests.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain.Tests/SoapClientTests.cs
@@ -1,0 +1,58 @@
+﻿using Mews.Fiscalizations.Spain.Communication;
+using Mews.Fiscalizations.Spain.Tests.IssuedInvoices;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace Mews.Fiscalizations.Spain.Tests
+{
+    [TestFixture]
+    public class SoapClientTests
+    {
+        private SoapClient soapClient;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            soapClient = new SoapClient(
+                endpointUri: new Uri("https://www7.aeat.es/wlpl/SSII-FACT/ws/fe/SiiFactFEV1SOAP"),
+                certificate: Basics.Certificate,
+                httpTimeout: TimeSpan.FromSeconds(30)
+            );
+        }
+
+        [System.SerializableAttribute]
+        [XmlRoot(ElementName = "SuministroLRFacturasEmitidas", Namespace = "https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroLR.xsd")]
+        [XmlType(TypeName = "SuministroLRFacturasEmitidas", AnonymousType = true, Namespace = "https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroLR.xsd")]
+        public class InvalidSoapMessage
+        {
+            [XmlElement("Message")]
+            public string Message { get; set; }
+        }
+
+        [XmlRoot("message")]
+        public class SomeSoapResponse
+        {
+            [XmlAttribute("value")]
+            public string Value { get; set; }
+        }
+
+        [Test]
+        public async Task InvalidSoapActionShouldFail()
+        {
+            try
+            {
+                await soapClient.SendAsync<InvalidSoapMessage, SomeSoapResponse>(new InvalidSoapMessage { Message = "bla-bla-bla" });
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+            Assert.Fail("Test was suppose to fail");
+        }
+    }
+}

--- a/src/Spain/Mews.Fiscalizations.Spain/Client.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Client.cs
@@ -31,18 +31,26 @@ namespace Mews.Fiscalizations.Spain
 
         private SoapClient SoapClient { get; }
 
-        public async Task<ReceivedInvoices> SubmitInvoiceAsync(InvoicesToSubmit model)
+        public async Task<ResponseResult<ReceivedInvoices>> SubmitInvoiceAsync(InvoicesToSubmit model)
         {
             var request = new ModelToDtoConverter().Convert(model);
             var response = await SoapClient.SendAsync<SubmitIssuedInvoicesRequest, SubmitIssuedInvoicesResponse>(request);
-            return new DtoToModelConverter().Convert(response);
+            return MapResponse(response);
         }
 
-        public async Task<ReceivedInvoices> SubmitSimplifiedInvoiceAsync(SimplifiedInvoicesToSubmit model)
+        public async Task<ResponseResult<ReceivedInvoices>> SubmitSimplifiedInvoiceAsync(SimplifiedInvoicesToSubmit model)
         {
             var request = new ModelToDtoConverter().Convert(model);
             var response = await SoapClient.SendAsync<SubmitIssuedInvoicesRequest, SubmitIssuedInvoicesResponse>(request);
-            return new DtoToModelConverter().Convert(response);
+            return MapResponse(response);
+        }
+
+        private static ResponseResult<ReceivedInvoices> MapResponse(ResponseResult<SubmitIssuedInvoicesResponse> response)
+        {
+            return response.IsSuccess.Match(
+                t => new ResponseResult<ReceivedInvoices>(successResult: new DtoToModelConverter().Convert(response.SuccessResult)),
+                f => new ResponseResult<ReceivedInvoices>(errorResult: response.ErrorResult)
+            );
         }
     }
 }

--- a/src/Spain/Mews.Fiscalizations.Spain/Communication/SoapClient.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Communication/SoapClient.cs
@@ -70,11 +70,7 @@ namespace Mews.Fiscalizations.Spain.Communication
             {
                 var result = await response.Content.ReadAsStringAsync();
 
-                stopwatch.Stop();
-                var duration = stopwatch.ElapsedMilliseconds;
-                HttpRequestFinished?.Invoke(this, new HttpRequestFinishedEventArgs(result, duration));
-
-                return result;
+                throw new Exception($"{response.StatusCode} {result}");
             }
         }
 

--- a/src/Spain/Mews.Fiscalizations.Spain/Communication/SoapClient.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Communication/SoapClient.cs
@@ -57,7 +57,11 @@ namespace Mews.Fiscalizations.Spain.Communication
             {
                 var result = await response.Content.ReadAsStringAsync();
 
-                throw new Exception($"{response.StatusCode} {result}");
+                stopwatch.Stop();
+                var duration = stopwatch.ElapsedMilliseconds;
+                HttpRequestFinished?.Invoke(this, new HttpRequestFinishedEventArgs(result, duration));
+
+                return result;
             }
         }
 

--- a/src/Spain/Mews.Fiscalizations.Spain/Communication/SoapClient.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Communication/SoapClient.cs
@@ -57,11 +57,7 @@ namespace Mews.Fiscalizations.Spain.Communication
             {
                 var result = await response.Content.ReadAsStringAsync();
 
-                stopwatch.Stop();
-                var duration = stopwatch.ElapsedMilliseconds;
-                HttpRequestFinished?.Invoke(this, new HttpRequestFinishedEventArgs(result, duration));
-
-                return result;
+                throw new Exception($"{response.StatusCode} {result}");
             }
         }
 

--- a/src/Spain/Mews.Fiscalizations.Spain/Communication/SoapClient.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Communication/SoapClient.cs
@@ -70,7 +70,11 @@ namespace Mews.Fiscalizations.Spain.Communication
             {
                 var result = await response.Content.ReadAsStringAsync();
 
-                throw new Exception($"{response.StatusCode} {result}");
+                stopwatch.Stop();
+                var duration = stopwatch.ElapsedMilliseconds;
+                HttpRequestFinished?.Invoke(this, new HttpRequestFinishedEventArgs(result, duration));
+
+                return result;
             }
         }
 

--- a/src/Spain/Mews.Fiscalizations.Spain/Dto/Responses/SoapFaultResponse.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Dto/Responses/SoapFaultResponse.cs
@@ -1,0 +1,40 @@
+﻿using System.Xml.Serialization;
+
+namespace Mews.Fiscalizations.Spain.Dto.Responses
+{
+	[XmlRoot(ElementName = "detail")]
+	public class Detail
+	{
+		[XmlElement(ElementName = "callstack")]
+		public string Callstack { get; set; }
+	}
+
+	[XmlRoot(ElementName = "Fault")]
+	public class Fault
+	{
+		[XmlElement(ElementName = "faultcode")]
+		public string Faultcode { get; set; }
+		[XmlElement(ElementName = "faultstring")]
+		public string Faultstring { get; set; }
+		[XmlElement(ElementName = "detail")]
+		public Detail Detail { get; set; }
+	}
+
+	[XmlRoot(ElementName = "Body")]
+	public class Body
+	{
+		[XmlElement(ElementName = "Fault")]
+		public Fault Fault { get; set; }
+	}
+
+	[XmlRoot(ElementName = "Envelope")]
+	public class SoapFaultResponse
+	{
+		[XmlElement(ElementName = "Body")]
+		public Body Body { get; set; }
+		[XmlAttribute(AttributeName = "env")]
+		public string Env { get; set; }
+		[XmlText]
+		public string Text { get; set; }
+	}
+}

--- a/src/Spain/Mews.Fiscalizations.Spain/Model/Response/ErrorResult.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Model/Response/ErrorResult.cs
@@ -1,0 +1,14 @@
+﻿namespace Mews.Fiscalizations.Spain.Model.Response
+{
+    public sealed class ErrorResult
+    {
+        public ErrorResult(string code, string message)
+        {
+            Code = code;
+            Message = message;
+        }
+
+        public string Code { get; }
+        public string Message { get; }
+    }
+}

--- a/src/Spain/Mews.Fiscalizations.Spain/Model/Response/ResponseResult.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Model/Response/ResponseResult.cs
@@ -1,0 +1,23 @@
+﻿using Mews.Fiscalizations.Core.Model;
+
+namespace Mews.Fiscalizations.Spain.Model.Response
+{
+    public class ResponseResult<TResult>
+        where TResult : class
+    {
+        internal ResponseResult(TResult successResult = null, ErrorResult errorResult = null)
+        {
+            SuccessResult = successResult;
+            ErrorResult = errorResult;
+        }
+
+        public TResult SuccessResult { get; }
+
+        public ErrorResult ErrorResult { get; }
+
+        public bool IsSuccess
+        {
+            get { return ErrorResult.IsNull(); }
+        }
+    }
+}

--- a/src/Spain/Mews.Fiscalizations.Spain/Nif/NifValidator.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Nif/NifValidator.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FuncSharp;
 using Mews.Fiscalizations.Core.Model;
 using Mews.Fiscalizations.Spain.Communication;
+using Mews.Fiscalizations.Spain.Model.Response;
 
 namespace Mews.Fiscalizations.Spain.Nif
 {
@@ -17,11 +18,14 @@ namespace Mews.Fiscalizations.Spain.Nif
         }
         private SoapClient SoapClient { get; }
 
-        public async Task<Response> CheckNif(Request model)
+        public async Task<ResponseResult<Response>> CheckNif(Request model)
         {
             var request = Convert(model);
             var response = await SoapClient.SendAsync<Entrada, Salida>(request);
-            return Convert(request, response);
+            return response.IsSuccess.Match(
+                t => new ResponseResult<Response>(successResult: Convert(request, response.SuccessResult)),
+                f => new ResponseResult<Response>(errorResult: response.ErrorResult)
+            );
         }
 
         private Response Convert(Entrada request, Salida response)

--- a/src/Spain/Mews.Fiscalizations.Spain/Properties/AssemblyInfo.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Mews.Fiscalizations.Spain.Tests")]


### PR DESCRIPTION
## Description

This this part 2 of PR series which suppose to add handling of soap failures.

In scope: add test which should cover invalid response from fiskaly.

Fixes [RND-80626](https://mews.myjetbrains.com/youtrack/issue/RND-80626)

## Type of change
- [ ] Bug fix.
- [x] Feature.
- [ ] Consolidation.

## Checklist
- [ ] Is breaking change.
- [ ] Documentation updated.
- [ ] Tests included (please specify cases).
