### PR TITLE
Add response logging on Nif validator

### DIFF
--- a/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
+++ b/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>6.0.1</PackageVersion>
+    <PackageVersion>6.0.2</PackageVersion>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
   

--- a/src/Spain/Mews.Fiscalizations.Spain/Mews.Fiscalizations.Spain.csproj
+++ b/src/Spain/Mews.Fiscalizations.Spain/Mews.Fiscalizations.Spain.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>7.0.1</PackageVersion>
+    <PackageVersion>7.0.2</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Spain/Mews.Fiscalizations.Spain/Nif/NifValidator.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Nif/NifValidator.cs
@@ -15,7 +15,14 @@ namespace Mews.Fiscalizations.Spain.Nif
         {
             var endpointUri = new Uri("https://www1.agenciatributaria.gob.es/wlpl/BURT-JDIT/ws/VNifV2SOAP");
             SoapClient = new SoapClient(endpointUri, certificate, httpTimeout);
+            SoapClient.HttpRequestFinished += (sender, args) => HttpRequestFinished?.Invoke(this, args);
+            SoapClient.XmlMessageSerialized += (sender, args) => XmlMessageSerialized?.Invoke(this, args);
         }
+
+        public event EventHandler<HttpRequestFinishedEventArgs> HttpRequestFinished;
+
+        public event EventHandler<XmlMessageSerializedEventArgs> XmlMessageSerialized;
+
         private SoapClient SoapClient { get; }
 
         public async Task<ITry<Response, ErrorResult>> CheckNif(Request model)


### PR DESCRIPTION
## Description

Sometimes Nif validator is failing [with invalid xml exception](https://mews.myjetbrains.com/youtrack/issue/RND-87866). We had this issue before but it was on client itself. Or so I thought. Unfortunately there is no logging of raw responses on Nif validator unlike client, so it is hard to investigate. I am adding logging via events - same way client does.

Fixes #issue

## Type of change
- [ ] Bug fix.
- [x] Feature.
- [ ] Consolidation.

## Checklist
- [ ] Is breaking change.
- [ ] Documentation updated.
- [ ] Tests included (please specify cases).
