### PR TITLE
Fixed an issue where libraries reference an old version of Mews.Fiscalizations.Core

### DIFF
--- a/src/Austria/Mews.Fiscalizations.Austria/Mews.Fiscalizations.Austria.csproj
+++ b/src/Austria/Mews.Fiscalizations.Austria/Mews.Fiscalizations.Austria.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>3.0.2</PackageVersion>
+    <PackageVersion>4.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Basque/Mews.Fiscalizations.Basque/Mews.Fiscalizations.Basque.csproj
+++ b/src/Basque/Mews.Fiscalizations.Basque/Mews.Fiscalizations.Basque.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>3.0.0-alpha</PackageVersion>
+    <PackageVersion>4.0.0-alpha</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/Mews.Fiscalizations.Core/Mews.Fiscalizations.Core.csproj
+++ b/src/Core/Mews.Fiscalizations.Core/Mews.Fiscalizations.Core.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>4.0.2</PackageVersion>
+    <PackageVersion>5.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Czechia/Mews.Fiscalizations.Czechia/Mews.Fiscalizations.Czechia.csproj
+++ b/src/Czechia/Mews.Fiscalizations.Czechia/Mews.Fiscalizations.Czechia.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>4.0.2</PackageVersion>
+    <PackageVersion>5.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Germany/Mews.Fiscalizations.Germany/Mews.Fiscalizations.Germany.csproj
+++ b/src/Germany/Mews.Fiscalizations.Germany/Mews.Fiscalizations.Germany.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>6.0.2</PackageVersion>
+    <PackageVersion>7.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Hungary/Mews.Fiscalizations.Hungary/Mews.Fiscalizations.Hungary.csproj
+++ b/src/Hungary/Mews.Fiscalizations.Hungary/Mews.Fiscalizations.Hungary.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>8.0.0</PackageVersion>
+    <PackageVersion>9.0.0</PackageVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Italy/Mews.Fiscalizations.Italy/Mews.Fiscalizations.Italy.csproj
+++ b/src/Italy/Mews.Fiscalizations.Italy/Mews.Fiscalizations.Italy.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>8.0.2</PackageVersion>
+    <PackageVersion>9.0.0</PackageVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
+++ b/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>12.0.0</PackageVersion>
+    <PackageVersion>13.0.0</PackageVersion>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
   

--- a/src/Spain/Mews.Fiscalizations.Spain/Mews.Fiscalizations.Spain.csproj
+++ b/src/Spain/Mews.Fiscalizations.Spain/Mews.Fiscalizations.Spain.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>8.0.3</PackageVersion>
+    <PackageVersion>9.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Fixed an issue where libraries reference an old version of Mews.Fiscalizations.Core.

https://github.com/MewsSystems/fiscalizations/issues/156

## Type of change
- [x] Bug fix.
- [ ] Feature.
- [ ] Consolidation.

## Checklist
- [ ] Is breaking change.
- [ ] Documentation updated.
- [ ] Tests included (please specify cases).
