### PR TITLE
Extended the Basque fiscalization to support the Alaba region

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -52,6 +52,9 @@ jobs:
         spanish_issuer_tax_number: ${{secrets.spanish_issuer_tax_number}}
         spanish_receiver_tax_number: ${{secrets.spanish_receiver_tax_number}}
 
+        basque_alaba_license: ${{secrets.basque_alaba_license}}
+        basque_gipuzkoa_license: ${{secrets.basque_gipuzkoa_license}}
+
         hungarian_login: ${{secrets.hungarian_login}}
         hungarian_password: ${{secrets.hungarian_password}}
         hungarian_signing_key: ${{secrets.hungarian_signing_key}}

--- a/.github/workflows/build-and-test-basque.yml
+++ b/.github/workflows/build-and-test-basque.yml
@@ -46,4 +46,6 @@ jobs:
         spanish_certificate_data: ${{secrets.spanish_certificate_data}}
         spanish_certificate_password: ${{secrets.spanish_certificate_password}}
         spanish_issuer_tax_number: ${{secrets.spanish_issuer_tax_number}}
+        basque_alaba_license: ${{secrets.basque_alaba_license}}
+        basque_gipuzkoa_license: ${{secrets.basque_gipuzkoa_license}}
       run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -48,6 +48,9 @@ jobs:
         spanish_issuer_tax_number: ${{secrets.spanish_issuer_tax_number}}
         spanish_receiver_tax_number: ${{secrets.spanish_receiver_tax_number}}
 
+        basque_alaba_license: ${{secrets.basque_alaba_license}}
+        basque_gipuzkoa_license: ${{secrets.basque_gipuzkoa_license}}
+
         hungarian_login: ${{secrets.hungarian_login}}
         hungarian_password: ${{secrets.hungarian_password}}
         hungarian_signing_key: ${{secrets.hungarian_signing_key}}

--- a/.github/workflows/publish-basque.yml
+++ b/.github/workflows/publish-basque.yml
@@ -42,6 +42,8 @@ jobs:
         spanish_certificate_data: ${{secrets.spanish_certificate_data}}
         spanish_certificate_password: ${{secrets.spanish_certificate_password}}
         spanish_issuer_tax_number: ${{secrets.spanish_issuer_tax_number}}
+        basque_alaba_license: ${{secrets.basque_alaba_license}}
+        basque_gipuzkoa_license: ${{secrets.basque_gipuzkoa_license}}
       run: dotnet test --no-restore --verbosity normal
 
   publish-basque:

--- a/src/Basque/Mews.Fiscalizations.Basque.Tests/InvoiceTestData.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque.Tests/InvoiceTestData.cs
@@ -8,10 +8,10 @@ namespace Mews.Fiscalizations.Basque.Tests
 {
     internal sealed class InvoiceTestData
     {
-        internal static SendInvoiceRequest CreateInvoiceRequest(Software software, bool localReceivers, bool negativeInvoice, OriginalInvoiceInfo originalInvoiceInfo = null)
+        internal static SendInvoiceRequest CreateInvoiceRequest(Issuer issuer, Software software, bool localReceivers, bool negativeInvoice, OriginalInvoiceInfo originalInvoiceInfo = null)
         {
             return new SendInvoiceRequest(
-                subject: CreateSubject(localReceivers),
+                subject: CreateSubject(issuer, localReceivers),
                 invoice: CreateInvoice(localReceivers, negativeInvoice),
                 invoiceFooter: new InvoiceFooter(software, originalInvoiceInfo: originalInvoiceInfo)
             );
@@ -114,9 +114,9 @@ namespace Mews.Fiscalizations.Basque.Tests
             );
         }
 
-        private static Subject CreateSubject(bool localReceivers)
+        private static Subject CreateSubject(Issuer issuer, bool localReceivers)
         {
-            return Subject.Create(TestFixture.Issuer, CreateReceivers(localReceivers), IssuerType.IssuedByThirdParty).Success.Get();
+            return Subject.Create(issuer, CreateReceivers(localReceivers), IssuerType.IssuedByThirdParty).Success.Get();
         }
 
         private static INonEmptyEnumerable<Receiver> CreateReceivers(bool localReceivers)

--- a/src/Basque/Mews.Fiscalizations.Basque.Tests/InvoiceTestData.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque.Tests/InvoiceTestData.cs
@@ -1,0 +1,151 @@
+﻿using FuncSharp;
+using Mews.Fiscalizations.Basque.Model;
+using Mews.Fiscalizations.Core.Model;
+using System;
+using System.Linq;
+
+namespace Mews.Fiscalizations.Basque.Tests
+{
+    internal sealed class InvoiceTestData
+    {
+        internal static SendInvoiceRequest CreateInvoiceRequest(Software software, bool localReceivers, bool negativeInvoice, OriginalInvoiceInfo originalInvoiceInfo = null)
+        {
+            return new SendInvoiceRequest(
+                subject: CreateSubject(localReceivers),
+                invoice: CreateInvoice(localReceivers, negativeInvoice),
+                invoiceFooter: new InvoiceFooter(software, originalInvoiceInfo: originalInvoiceInfo)
+            );
+        }
+
+        private static Invoice CreateInvoice(bool localReceivers, bool negativeInvoice)
+        {
+            return new Invoice(CreateHeader(), CreateInvoiceData(negativeInvoice), CreateTaxBreakdown(localReceivers, negativeInvoice));
+        }
+
+        private static TaxBreakdown CreateTaxBreakdown(bool localReceivers, bool negativeInvoice)
+        {
+            var baseValue = negativeInvoice.Match(
+                t => -73.86m,
+                f => 73.86m
+            );
+            var taxSummary = TaxSummary.Create(taxed: CreateTaxRateSummary(21m, baseValue).ToEnumerable().ToArray()).Success.Get();
+            return localReceivers.Match(
+                t => new TaxBreakdown(taxSummary),
+                f => new TaxBreakdown(OperationTypeTaxBreakdown.Create(delivery: taxSummary).Success.Get())
+            );
+        }
+
+        private static InvoiceData CreateInvoiceData(bool negativeInvoice)
+        {
+            return InvoiceData.Create(
+                description: String1To250.CreateUnsafe("TicketBAI sample invoice test."),
+                items: CreateInvoiceItems(negativeInvoice),
+                totalAmount: negativeInvoice.Match(t => -89.36m, f => 89.36m),
+                taxModes: TaxMode.GeneralTaxRegimeActivity.ToEnumerable(),
+                transactionDate: DateTime.Now
+            ).Success.Get();
+        }
+
+        private static INonEmptyEnumerable<InvoiceItem> CreateInvoiceItems(bool negativeInvoice)
+        {
+            return negativeInvoice.Match(
+                t => NonEmptyEnumerable.Create(
+                    new InvoiceItem(
+                        description: String1To250.CreateUnsafe("Night 1"),
+                        quantity: 1,
+                        unitAmount: -23.356m,
+                        discount: -2.00m,
+                        totalAmount: -25.84m
+                    ),
+                    new InvoiceItem(
+                        description: String1To250.CreateUnsafe("Night 2"),
+                        quantity: 1.50m,
+                        unitAmount: -18.2m,
+                        totalAmount: -33.03m
+                    ),
+                    new InvoiceItem(
+                        description: String1To250.CreateUnsafe("Parking"),
+                        quantity: 18,
+                        unitAmount: -1.40m,
+                        totalAmount: -30.49m
+                    )
+                ),
+                f => NonEmptyEnumerable.Create(
+                    new InvoiceItem(
+                        description: String1To250.CreateUnsafe("Night 1"),
+                        quantity: 1,
+                        unitAmount: 23.356m,
+                        discount: 2.00m,
+                        totalAmount: 25.84m
+                    ),
+                    new InvoiceItem(
+                        description: String1To250.CreateUnsafe("Night 2"),
+                        quantity: 1.50m,
+                        unitAmount: 18.2m,
+                        totalAmount: 33.03m
+                    ),
+                    new InvoiceItem(
+                        description: String1To250.CreateUnsafe("Parking"),
+                        quantity: 18,
+                        unitAmount: 1.40m,
+                        totalAmount: 30.49m
+                    )
+                )
+            );
+        }
+
+        private static InvoiceHeader CreateHeader()
+        {
+            var randomString = String1To20.CreateUnsafe(Guid.NewGuid().ToString().Substring(0, 19));
+            return new InvoiceHeader(
+                number: randomString,
+                issued: DateTime.Now,
+                series: randomString,
+                correctingInvoice: new CorrectingInvoice(
+                    code: CorrectingInvoiceCode.CorrectedInvoice,
+                    type: CorrectingInvoiceType.CorrectiveInvoiceForReplacement,
+                    amount: new CorrectingInvoiceAmount(10, 10, 10)
+                ),
+                correctedInvoices: NonEmptyEnumerable.Create(new CorrectedInvoice(
+                    series: randomString,
+                    number: randomString,
+                    issueDate: DateTime.Now
+                ))
+            );
+        }
+
+        private static Subject CreateSubject(bool localReceivers)
+        {
+            return Subject.Create(TestFixture.Issuer, CreateReceivers(localReceivers), IssuerType.IssuedByThirdParty).Success.Get();
+        }
+
+        private static INonEmptyEnumerable<Receiver> CreateReceivers(bool localReceivers)
+        {
+            return NonEmptyEnumerable.Create(localReceivers.Match(
+                t => Receiver.Local(
+                    nif: TaxpayerIdentificationNumber.Create(Countries.Spain, "11111111H").Success.Get(),
+                    name: Name.CreateUnsafe("Mike The Local"),
+                    postalCode: PostalCode.CreateUnsafe("08013"),
+                    address: String1To250.CreateUnsafe("C/ de Mallorca, 401, Barcelona")
+                ),
+                f => Receiver.Foreign(
+                    idType: IdType.Passport,
+                    id: String1To20.CreateUnsafe("ABCDEF123"),
+                    name: Name.CreateUnsafe("John The Forienger"),
+                    postalCode: PostalCode.CreateUnsafe("10202"),
+                    address: String1To250.CreateUnsafe("Prague, Italska 2502/555"),
+                    country: Countries.CzechRepublic
+                )
+            ));
+        }
+
+        private static TaxRateSummary CreateTaxRateSummary(decimal vat, decimal baseValue)
+        {
+            return new TaxRateSummary(
+                taxRatePercentage: Percentage.Create(vat).Success.Get(),
+                taxBaseAmount: Amount.Create(baseValue).Success.Get(),
+                taxAmount: Amount.Create(Math.Round(baseValue * vat / 100, 2)).Success.Get()
+            );
+        }
+    }
+}

--- a/src/Basque/Mews.Fiscalizations.Basque.Tests/SendInvoiceTests.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque.Tests/SendInvoiceTests.cs
@@ -21,7 +21,7 @@ namespace Mews.Fiscalizations.Basque.Tests
         public async Task SendSimpleInvoiceSucceeds(Region region, bool localReceivers, bool negativeInvoice)
         {
             var testFixture = new TestFixture(region);
-            var request = InvoiceTestData.CreateInvoiceRequest(testFixture.Software, localReceivers, negativeInvoice);
+            var request = InvoiceTestData.CreateInvoiceRequest(testFixture.Issuer, testFixture.Software, localReceivers, negativeInvoice);
             var response = await testFixture.Client.SendInvoiceAsync(request);
             TestFixture.AssertResponse(region, response);
         }
@@ -33,12 +33,12 @@ namespace Mews.Fiscalizations.Basque.Tests
         public async Task SendChainedInvoiceSucceeds(Region region)
         {
             var testFixture = new TestFixture(region);
-            var request1 = InvoiceTestData.CreateInvoiceRequest(testFixture.Software, localReceivers: true, negativeInvoice: false);
+            var request1 = InvoiceTestData.CreateInvoiceRequest(testFixture.Issuer, testFixture.Software, localReceivers: true, negativeInvoice: false);
             var response1 = await testFixture.Client.SendInvoiceAsync(request1);
             TestFixture.AssertResponse(region, response1);
 
             var originalInvoiceHeader = request1.Invoice.Header;
-            var request2 = InvoiceTestData.CreateInvoiceRequest(testFixture.Software, localReceivers: true, negativeInvoice: false, originalInvoiceInfo: new OriginalInvoiceInfo(
+            var request2 = InvoiceTestData.CreateInvoiceRequest(testFixture.Issuer, testFixture.Software, localReceivers: true, negativeInvoice: false, originalInvoiceInfo: new OriginalInvoiceInfo(
                 number: originalInvoiceHeader.Number,
                 issueDate: originalInvoiceHeader.Issued,
                 signature: response1.SignatureValue,

--- a/src/Basque/Mews.Fiscalizations.Basque.Tests/SendInvoiceTests.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque.Tests/SendInvoiceTests.cs
@@ -1,9 +1,6 @@
 ﻿using FuncSharp;
 using Mews.Fiscalizations.Basque.Model;
-using Mews.Fiscalizations.Core.Model;
 using NUnit.Framework;
-using System;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Mews.Fiscalizations.Basque.Tests
@@ -12,175 +9,43 @@ namespace Mews.Fiscalizations.Basque.Tests
     public class SendInvoiceTests
     {
         [Test]
-        [TestCase(false, false, TestName = "Send invoice with local receiver")]
-        [TestCase(true, false, TestName = "Send invoice with foreign receiver")]
-        [TestCase(false, true, TestName = "Send negative invoice with local receiver")]
-        [TestCase(true, true, TestName = "Send negative invoice with foreign receiver")]
+        [TestCase(Region.Alaba, false, false, TestName = "Alaba - Send invoice with local receiver")]
+        [TestCase(Region.Alaba, true, false, TestName = "Alaba - Send invoice with foreign receiver")]
+        [TestCase(Region.Alaba, false, true, TestName = "Alaba - Send negative invoice with local receiver")]
+        [TestCase(Region.Alaba, true, true, TestName = "Alaba - Send negative invoice with foreign receiver")]
+        [TestCase(Region.Gipuzkoa, false, false, TestName = "Gipuzkoa - Send invoice with local receiver")]
+        [TestCase(Region.Gipuzkoa, true, false, TestName = "Gipuzkoa - Send invoice with foreign receiver")]
+        [TestCase(Region.Gipuzkoa, false, true, TestName = "Gipuzkoa - Send negative invoice with local receiver")]
+        [TestCase(Region.Gipuzkoa, true, true, TestName = "Gipuzkoa - Send negative invoice with foreign receiver")]
         [Retry(3)]
-        public async Task SendSimpleInvoiceSucceeds(bool localReceivers, bool negativeInvoice)
+        public async Task SendSimpleInvoiceSucceeds(Region region, bool localReceivers, bool negativeInvoice)
         {
-            var request = CreateInvoiceRequest(localReceivers, negativeInvoice);
-            var response = await TestFixture.Client.SendInvoiceAsync(request);
-            TestFixture.AssertResponse(response);
+            var testFixture = new TestFixture(region);
+            var request = InvoiceTestData.CreateInvoiceRequest(testFixture.Software, localReceivers, negativeInvoice);
+            var response = await testFixture.Client.SendInvoiceAsync(request);
+            TestFixture.AssertResponse(region, response);
         }
 
         [Test]
+        [TestCase(Region.Alaba, TestName = "Alaba - Invoice chaining")]
+        [TestCase(Region.Gipuzkoa, TestName = "Gipuzkoa - Invoice chaining")]
         [Retry(3)]
-        public async Task SendChainedInvoiceSucceeds()
+        public async Task SendChainedInvoiceSucceeds(Region region)
         {
-            var request1 = CreateInvoiceRequest(localReceivers: true, negativeInvoice: false);
-            var response1 = await TestFixture.Client.SendInvoiceAsync(request1);
-            TestFixture.AssertResponse(response1);
+            var testFixture = new TestFixture(region);
+            var request1 = InvoiceTestData.CreateInvoiceRequest(testFixture.Software, localReceivers: true, negativeInvoice: false);
+            var response1 = await testFixture.Client.SendInvoiceAsync(request1);
+            TestFixture.AssertResponse(region, response1);
 
             var originalInvoiceHeader = request1.Invoice.Header;
-            var request2 = CreateInvoiceRequest(localReceivers: true, negativeInvoice: false, originalInvoiceInfo: new OriginalInvoiceInfo(
+            var request2 = InvoiceTestData.CreateInvoiceRequest(testFixture.Software, localReceivers: true, negativeInvoice: false, originalInvoiceInfo: new OriginalInvoiceInfo(
                 number: originalInvoiceHeader.Number,
                 issueDate: originalInvoiceHeader.Issued,
                 signature: response1.SignatureValue,
                 series: originalInvoiceHeader.Series.GetOrNull()
             ));
-            var response2 = await TestFixture.Client.SendInvoiceAsync(request2);
-            TestFixture.AssertResponse(response2);
-        }
-
-        internal static SendInvoiceRequest CreateInvoiceRequest(bool localReceivers, bool negativeInvoice, OriginalInvoiceInfo originalInvoiceInfo = null)
-        {
-            return new SendInvoiceRequest(
-                subject: CreateSubject(localReceivers),
-                invoice: CreateInvoice(localReceivers, negativeInvoice),
-                invoiceFooter: new InvoiceFooter(TestFixture.Software, originalInvoiceInfo: originalInvoiceInfo)
-            );
-        }
-
-        private static Invoice CreateInvoice(bool localReceivers, bool negativeInvoice)
-        {
-            return new Invoice(CreateHeader(), CreateInvoiceData(negativeInvoice), CreateTaxBreakdown(localReceivers, negativeInvoice));
-        }
-
-        private static TaxBreakdown CreateTaxBreakdown(bool localReceivers, bool negativeInvoice)
-        {
-            var baseValue = negativeInvoice.Match(
-                t => -73.86m,
-                f => 73.86m
-            );
-            var taxSummary = TaxSummary.Create(taxed: CreateTaxRateSummary(21m, baseValue).ToEnumerable().ToArray()).Success.Get();
-            return localReceivers.Match(
-                t => new TaxBreakdown(taxSummary),
-                f => new TaxBreakdown(OperationTypeTaxBreakdown.Create(delivery: taxSummary).Success.Get())
-            );
-        }
-
-        private static InvoiceData CreateInvoiceData(bool negativeInvoice)
-        {
-            return InvoiceData.Create(
-                description: String1To250.CreateUnsafe("TicketBAI sample invoice test."),
-                items: CreateInvoiceItems(negativeInvoice),
-                totalAmount: negativeInvoice.Match(t => -89.36m, f => 89.36m),
-                taxModes: TaxMode.GeneralTaxRegimeActivity.ToEnumerable(),
-                transactionDate: DateTime.Now
-            ).Success.Get();
-        }
-
-        private static INonEmptyEnumerable<InvoiceItem> CreateInvoiceItems(bool negativeInvoice)
-        {
-            return negativeInvoice.Match(
-                t => NonEmptyEnumerable.Create(
-                    new InvoiceItem(
-                        description: String1To250.CreateUnsafe("Night 1"),
-                        quantity: 1,
-                        unitAmount: -23.356m,
-                        discount: -2.00m,
-                        totalAmount: -25.84m
-                    ),
-                    new InvoiceItem(
-                        description: String1To250.CreateUnsafe("Night 2"),
-                        quantity: 1.50m,
-                        unitAmount: -18.2m,
-                        totalAmount: -33.03m
-                    ),
-                    new InvoiceItem(
-                        description: String1To250.CreateUnsafe("Parking"),
-                        quantity: 18,
-                        unitAmount: -1.40m,
-                        totalAmount: -30.49m
-                    )
-                ),
-                f => NonEmptyEnumerable.Create(
-                    new InvoiceItem(
-                        description: String1To250.CreateUnsafe("Night 1"),
-                        quantity: 1,
-                        unitAmount: 23.356m,
-                        discount: 2.00m,
-                        totalAmount: 25.84m
-                    ),
-                    new InvoiceItem(
-                        description: String1To250.CreateUnsafe("Night 2"),
-                        quantity: 1.50m,
-                        unitAmount: 18.2m,
-                        totalAmount: 33.03m
-                    ),
-                    new InvoiceItem(
-                        description: String1To250.CreateUnsafe("Parking"),
-                        quantity: 18,
-                        unitAmount: 1.40m,
-                        totalAmount: 30.49m
-                    )
-                )
-            );
-        }
-
-        private static InvoiceHeader CreateHeader()
-        {
-            var randomString = String1To20.CreateUnsafe(Guid.NewGuid().ToString().Substring(0, 19));
-            return new InvoiceHeader(
-                number: randomString,
-                issued: DateTime.Now,
-                series: randomString,
-                correctingInvoice: new CorrectingInvoice(
-                    code: CorrectingInvoiceCode.CorrectedInvoice,
-                    type: CorrectingInvoiceType.CorrectiveInvoiceForReplacement,
-                    amount: new CorrectingInvoiceAmount(10, 10, 10)
-                ),
-                correctedInvoices: NonEmptyEnumerable.Create(new CorrectedInvoice(
-                    series: randomString,
-                    number: randomString,
-                    issueDate: DateTime.Now
-                ))
-            );
-        }
-
-        private static Subject CreateSubject(bool localReceivers)
-        {
-            return Subject.Create(TestFixture.Issuer, CreateReceivers(localReceivers), IssuerType.IssuedByThirdParty).Success.Get();
-        }
-
-        private static INonEmptyEnumerable<Receiver> CreateReceivers(bool localReceivers)
-        {
-            return NonEmptyEnumerable.Create(localReceivers.Match(
-                t => Receiver.Local(
-                    nif: TaxpayerIdentificationNumber.Create(Countries.Spain, "11111111H").Success.Get(),
-                    name: Name.CreateUnsafe("Mike The Local"),
-                    postalCode: PostalCode.CreateUnsafe("08013"),
-                    address: String1To250.CreateUnsafe("C/ de Mallorca, 401, Barcelona")
-                ),
-                f => Receiver.Foreign(
-                    idType: IdType.Passport,
-                    id: String1To20.CreateUnsafe("ABCDEF123"),
-                    name: Name.CreateUnsafe("John The Forienger"),
-                    postalCode: PostalCode.CreateUnsafe("10202"),
-                    address: String1To250.CreateUnsafe("Prague, Italska 2502/555"),
-                    country: Countries.CzechRepublic
-                )
-            ));
-        }
-
-        private static TaxRateSummary CreateTaxRateSummary(decimal vat, decimal baseValue)
-        {
-            return new TaxRateSummary(
-                taxRatePercentage: Percentage.Create(vat).Success.Get(),
-                taxBaseAmount: Amount.Create(baseValue).Success.Get(),
-                taxAmount: Amount.Create(Math.Round(baseValue * vat / 100, 2)).Success.Get()
-            );
+            var response2 = await testFixture.Client.SendInvoiceAsync(request2);
+            TestFixture.AssertResponse(region, response2);
         }
     }
 }

--- a/src/Basque/Mews.Fiscalizations.Basque.Tests/TestFixture.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque.Tests/TestFixture.cs
@@ -3,11 +3,12 @@ using Mews.Fiscalizations.Basque.Model;
 using Mews.Fiscalizations.Core.Model;
 using NUnit.Framework;
 using System;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Mews.Fiscalizations.Basque.Tests
 {
-    public static class TestFixture
+    public sealed class TestFixture
     {
         internal static readonly X509Certificate2 Certificate = new X509Certificate2(
             rawData: Convert.FromBase64String(System.Environment.GetEnvironmentVariable("spanish_certificate_data") ?? "INSERT_CERTIFICATE_DATA"),
@@ -20,18 +21,35 @@ namespace Mews.Fiscalizations.Basque.Tests
             nif: TaxpayerIdentificationNumber.Create(Countries.Spain, System.Environment.GetEnvironmentVariable("spanish_issuer_tax_number") ?? "INSERT_TAX_ID").Success.Get()
         );
 
-        internal static readonly TicketBaiClient Client = new TicketBaiClient(Certificate, Environment.Test);
+        public TestFixture(Region region)
+        {
+            Region = region;
+        }
 
-        internal static readonly Software Software = Software.LocalSoftwareDeveloper(
+        internal Region Region { get; }
+
+        internal TicketBaiClient Client => new TicketBaiClient(Certificate, Region, Environment.Test);
+
+        internal Software Software => Software.LocalSoftwareDeveloper(
             nif: Issuer.Nif,
-            license: String1To20.CreateUnsafe("TBAIARblKjHKdjl00391"),
+            license: Region.Match(
+                Region.Alaba, _ => String1To20.CreateUnsafe(System.Environment.GetEnvironmentVariable("basque_alaba_license") ?? "INSERT_LICENSE"),
+                Region.Gipuzkoa, _ => String1To20.CreateUnsafe(System.Environment.GetEnvironmentVariable("basque_gipuzkoa_license") ?? "INSERT_LICENSE")
+            ),
             name: String1To120.CreateUnsafe("Test"),
             version: String1To20.CreateUnsafe("1.0.0")
         );
 
-        internal static void AssertResponse(SendInvoiceResponse response)
+        internal static void AssertResponse(Region region, SendInvoiceResponse response)
         {
-            Assert.IsEmpty(response.ValidationResults.Flatten());
+            var validationResults = response.ValidationResults.Flatten();
+
+            // Alaba region validates that each invoice is chained, but that's something we can't do in tests, so we will be ignoring that error.
+            var applicableValidationResults = region.Match(
+                Region.Gipuzkoa, _ => validationResults,
+                Region.Alaba, _ => validationResults.Where(r => !r.ErrorCode.Equals(ErrorCode.InvalidOrMissingInvoiceChain))
+            );
+            Assert.IsEmpty(applicableValidationResults);
             Assert.IsNotEmpty(response.QrCodeUri);
             Assert.IsNotEmpty(response.TBAIIdentifier);
             Assert.IsNotEmpty(response.XmlRequestContent);

--- a/src/Basque/Mews.Fiscalizations.Basque.Tests/TestFixture.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque.Tests/TestFixture.cs
@@ -21,8 +21,6 @@ namespace Mews.Fiscalizations.Basque.Tests
             taxpayerNumber: System.Environment.GetEnvironmentVariable("spanish_issuer_tax_number") ?? "INSERT_TAX_ID"
         ).Success.Get();
 
-        internal static readonly Issuer Issuer = new Issuer(LocalNif, Name.CreateUnsafe("Test issuing company"));
-
         public TestFixture(Region region)
         {
             Region = region;
@@ -33,10 +31,7 @@ namespace Mews.Fiscalizations.Basque.Tests
         internal TicketBaiClient Client => new TicketBaiClient(Certificate, Region, Environment.Test);
 
         internal Software Software => Software.LocalSoftwareDeveloper(
-            nif: Region.Match(
-                Region.Gipuzkoa, _ => Issuer.Nif,
-                Region.Alaba, _ => TaxpayerIdentificationNumber.Create(Countries.Spain, "A01111111").Success.Get() // For Alaba, the NIF must be registered in the region.
-            ),
+            nif: LocalNif,
             license: Region.Match(
                 Region.Alaba, _ => String1To20.CreateUnsafe(System.Environment.GetEnvironmentVariable("basque_alaba_license") ?? "INSERT_LICENSE"),
                 Region.Gipuzkoa, _ => String1To20.CreateUnsafe(System.Environment.GetEnvironmentVariable("basque_gipuzkoa_license") ?? "INSERT_LICENSE")
@@ -44,6 +39,11 @@ namespace Mews.Fiscalizations.Basque.Tests
             name: String1To120.CreateUnsafe("Test"),
             version: String1To20.CreateUnsafe("1.0.0")
         );
+
+        internal Issuer Issuer => new Issuer(name: Name.CreateUnsafe("Test issuing company"), nif: Region.Match(
+            Region.Gipuzkoa, _ => LocalNif,
+            Region.Alaba, _ => TaxpayerIdentificationNumber.Create(Countries.Spain, "A01111111").Success.Get() // For Alaba, the NIF must be registered in the region.
+        ));
 
         internal static void AssertResponse(Region region, SendInvoiceResponse response)
         {

--- a/src/Basque/Mews.Fiscalizations.Basque/Mews.Fiscalizations.Basque.csproj
+++ b/src/Basque/Mews.Fiscalizations.Basque/Mews.Fiscalizations.Basque.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>4.0.3-alpha</PackageVersion>
+    <PackageVersion>1.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Basque/Mews.Fiscalizations.Basque/Model/ErrorCode.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque/Model/ErrorCode.cs
@@ -29,6 +29,9 @@
         // The signature must be valid or the signing certificate must not be expired (more than one month).
         InvalidSignatureOrSigningCertificate = 08,
 
+        // Invalid or missing chain.
+        InvalidOrMissingInvoiceChain = 09,
+
         // The rectified (Corrected) invoice is not indicated.
         CorrectedInvoiceNotIndicated = 011,
 

--- a/src/Basque/Mews.Fiscalizations.Basque/ModelToDtoConverter.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque/ModelToDtoConverter.cs
@@ -9,13 +9,13 @@ namespace Mews.Fiscalizations.Basque
 {
     internal static class ModelToDtoConverter
     {
-        public static Dto.TicketBai Convert(SendInvoiceRequest sendInvoiceRequest)
+        public static Dto.TicketBai Convert(SendInvoiceRequest sendInvoiceRequest, ServiceInfo serviceInfo)
         {
             return new Dto.TicketBai
             {
                 Cabecera = new Cabecera1
                 {
-                    IDVersionTBAI = ServiceInfo.Version
+                    IDVersionTBAI = serviceInfo.Version
                 },
                 Sujetos = Convert(sendInvoiceRequest.Subject),
                 Factura = Convert(sendInvoiceRequest.Invoice),

--- a/src/Basque/Mews.Fiscalizations.Basque/QrCodeUriGenerator.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque/QrCodeUriGenerator.cs
@@ -50,21 +50,27 @@ namespace Mews.Fiscalizations.Basque
         /// Total amount (i) and the CRC-8 error-detecting-code (cr).
         /// Example: https://batuz.eus/QRTBAI/?id=TBAI-00000006Y-251019-btFpwP8dcLGAF-237&s=T&nf=27174&i=4.70&cr=007
         /// </summary>
-        internal static string Generate(Environment environment, string tbaiIdentifier, IOption<String1To20> invoiceSeries, string invoiceNumber, decimal total)
+        internal static string Generate(
+            ServiceInfo serviceInfo,
+            Environment environment,
+            string tbaiIdentifier,
+            IOption<String1To20> invoiceSeries,
+            string invoiceNumber,
+            decimal total)
         {
-            var qrUri = $"{ServiceInfo.QrBaseUrls[environment]}{ServiceInfo.RelativeQrCodeUri}?id={tbaiIdentifier}";
+            var qrUri = $"{serviceInfo.QrBaseUrls[environment]}{serviceInfo.RelativeQrCodeUri}?id={tbaiIdentifier}";
             var query = QueryHelpers.AddQueryString(qrUri, new Dictionary<string, string>
             {
                 { "s", invoiceSeries.Map(s => s.Value).GetOrElse("") },
                 { "nf", invoiceNumber },
                 { "i", total.ToString(CultureInfo.InvariantCulture) }
             });
-            return QueryHelpers.AddQueryString(query, "cr", GetCyclicRedundancyCheckDigits(query));
+            return QueryHelpers.AddQueryString(query, "cr", GetCyclicRedundancyCheckDigits(query, serviceInfo));
         }
 
-        private static string GetCyclicRedundancyCheckDigits(string qrCodeUri)
+        private static string GetCyclicRedundancyCheckDigits(string qrCodeUri, ServiceInfo serviceInfo)
         {
-            var data = ServiceInfo.Encoding.GetBytes(qrCodeUri);
+            var data = serviceInfo.Encoding.GetBytes(qrCodeUri);
             var crc = (byte)0;
             for (int i = 0; i < data.Length; i++)
             {

--- a/src/Basque/Mews.Fiscalizations.Basque/Region.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque/Region.cs
@@ -1,0 +1,8 @@
+﻿namespace Mews.Fiscalizations.Basque
+{
+    public enum Region
+    {
+        Gipuzkoa,
+        Alaba
+    }
+}

--- a/src/Basque/Mews.Fiscalizations.Basque/ServiceInfo.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque/ServiceInfo.cs
@@ -1,43 +1,64 @@
-﻿using Mews.Fiscalizations.Basque.Dto;
+﻿using FuncSharp;
+using Mews.Fiscalizations.Basque.Dto;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace Mews.Fiscalizations.Basque
 {
-    public static class ServiceInfo
+    public sealed class ServiceInfo
     {
-        internal static IDVersionTicketBaiType1 Version { get; }
-
-        internal static Dictionary<Environment, Uri> InvoiceBaseUrls { get; }
-
-        internal static Dictionary<Environment, Uri> QrBaseUrls { get; }
-
-        internal static Uri RelativeSendInvoiceUri { get; }
-
-        internal static Uri RelativeQrCodeUri { get; }
-
-        internal static Encoding Encoding { get; }
-
-        static ServiceInfo()
+        public ServiceInfo(Region region)
         {
             Version = IDVersionTicketBaiType1.Item12;
-            InvoiceBaseUrls = new Dictionary<Environment, Uri>
-            {
-                [Environment.Test] = new Uri("https://tbai-z.prep.gipuzkoa.eus"),
-                [Environment.Production] = new Uri("https://tbai-z.egoitza.gipuzkoa.eus")
-            };
-            QrBaseUrls = new Dictionary<Environment, Uri>
-            {
-                [Environment.Test] = new Uri("https://tbai.prep.gipuzkoa.eus"),
-                [Environment.Production] = new Uri("https://tbai.egoitza.gipuzkoa.eus")
-            };
-            RelativeSendInvoiceUri = new Uri("sarrerak/alta/", UriKind.Relative);
-            RelativeQrCodeUri = new Uri("qr/", UriKind.Relative);
+            InvoiceBaseUrls = region.Match(
+                Region.Gipuzkoa, _ => new Dictionary<Environment, Uri>
+                {
+                    [Environment.Test] = new Uri("https://tbai-z.prep.gipuzkoa.eus"),
+                    [Environment.Production] = new Uri("https://tbai-z.egoitza.gipuzkoa.eus")
+                },
+                Region.Alaba, _ => new Dictionary<Environment, Uri>
+                {
+                    [Environment.Test] = new Uri("https://pruebas-ticketbai.araba.eus"),
+                    [Environment.Production] = new Uri("https://ticketbai.araba.eus")
+                }
+            );
+            QrBaseUrls = region.Match(
+                Region.Gipuzkoa, _ => new Dictionary<Environment, Uri>
+                {
+                    [Environment.Test] = new Uri("https://tbai.prep.gipuzkoa.eus"),
+                    [Environment.Production] = new Uri("https://tbai.egoitza.gipuzkoa.eus")
+                },
+                Region.Alaba, _ => new Dictionary<Environment, Uri>
+                {
+                    [Environment.Test] = new Uri("https://pruebas-ticketbai.araba.eus"),
+                    [Environment.Production] = new Uri("https://ticketbai.araba.eus")
+                }
+            );
+            RelativeSendInvoiceUri = region.Match(
+                Region.Gipuzkoa, _ => new Uri("sarrerak/alta/", UriKind.Relative),
+                Region.Alaba, _ => new Uri("TicketBAI/v1/facturas/", UriKind.Relative)
+            );
+            RelativeQrCodeUri = region.Match(
+                Region.Gipuzkoa, _ => new Uri("qr/", UriKind.Relative),
+                Region.Alaba, _ => new Uri("tbai/qrtbai/", UriKind.Relative)
+            );
             Encoding = Encoding.UTF8;
         }
 
-        internal static Uri SendInvoiceUri(Environment environment)
+        internal IDVersionTicketBaiType1 Version { get; }
+
+        internal Dictionary<Environment, Uri> InvoiceBaseUrls { get; }
+
+        internal Dictionary<Environment, Uri> QrBaseUrls { get; }
+
+        internal Uri RelativeSendInvoiceUri { get; }
+
+        internal Uri RelativeQrCodeUri { get; }
+
+        internal Encoding Encoding { get; }
+
+        internal Uri SendInvoiceUri(Environment environment)
         {
             return new Uri(InvoiceBaseUrls[environment], RelativeSendInvoiceUri);
         }

--- a/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
+++ b/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>14.0.4</PackageVersion>
+    <PackageVersion>15.0.0</PackageVersion>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
   


### PR DESCRIPTION
## Description

Extended the Basque fiscalization to support the Alaba region.

Both DTOs and validations are identical, the only difference is the API URL/endpoints.
The clients don't have to worry about anything, all you need to do is provide the Region (Alaba or Gipuzkoa) when creating the ticket bai client.

## Type of change
- [ ] Bug fix.
- [x] Feature.
- [ ] Consolidation.

## Checklist
- [x] Is breaking change.
- [ ] Documentation updated.
- [ ] Tests included (please specify cases).
