### PR TITLE
Fixed the Basque fiscalization postal code validations

### DIFF
--- a/src/Basque/Mews.Fiscalizations.Basque.Tests/InvoiceTestData.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque.Tests/InvoiceTestData.cs
@@ -132,7 +132,7 @@ namespace Mews.Fiscalizations.Basque.Tests
                     idType: IdType.Passport,
                     id: String1To20.CreateUnsafe("ABCDEF123"),
                     name: Name.CreateUnsafe("John The Forienger"),
-                    postalCode: PostalCode.CreateUnsafe("12345678912345678BBAA"),
+                    postalCode: PostalCode.CreateUnsafe("12345678912345678BBA"),
                     address: String1To250.CreateUnsafe("Prague, Italska 2502/555"),
                     country: Countries.CzechRepublic
                 )

--- a/src/Basque/Mews.Fiscalizations.Basque.Tests/InvoiceTestData.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque.Tests/InvoiceTestData.cs
@@ -132,7 +132,7 @@ namespace Mews.Fiscalizations.Basque.Tests
                     idType: IdType.Passport,
                     id: String1To20.CreateUnsafe("ABCDEF123"),
                     name: Name.CreateUnsafe("John The Forienger"),
-                    postalCode: PostalCode.CreateUnsafe("10202"),
+                    postalCode: PostalCode.CreateUnsafe("12345678912345678BBAA"),
                     address: String1To250.CreateUnsafe("Prague, Italska 2502/555"),
                     country: Countries.CzechRepublic
                 )

--- a/src/Basque/Mews.Fiscalizations.Basque.Tests/ValidationTests.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque.Tests/ValidationTests.cs
@@ -1,0 +1,22 @@
+﻿using Mews.Fiscalizations.Basque.Model;
+using NUnit.Framework;
+
+namespace Mews.Fiscalizations.Basque.Tests
+{
+    [TestFixture]
+    public sealed class ValidationTests
+    {
+        [Test]
+        [TestCase("12345", true)]
+        [TestCase("ABCDEFG", true)]
+        [TestCase("ABCDEF123456", true)]
+        [TestCase("12345@", false)]
+        [TestCase("123456789123456789102", false)]
+        [TestCase("", false)]
+        [TestCase(" ", false)]
+        public void PostalCodeTests(string postalCode, bool isValid)
+        {
+            Assert.AreEqual(PostalCode.Create(postalCode).IsSuccess, isValid);
+        }
+    }
+}

--- a/src/Basque/Mews.Fiscalizations.Basque/Mews.Fiscalizations.Basque.csproj
+++ b/src/Basque/Mews.Fiscalizations.Basque/Mews.Fiscalizations.Basque.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>4.0.0</PackageVersion>
+    <PackageVersion>4.1.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Basque/Mews.Fiscalizations.Basque/Model/PostalCode.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque/Model/PostalCode.cs
@@ -15,7 +15,7 @@ namespace Mews.Fiscalizations.Basque.Model
 
         public static ITry<PostalCode, Error> Create(string value)
         {
-            return StringValidations.RegexMatch(value, new Regex("^[0-9]{1,5}$")).Map(v => new PostalCode(v));
+            return StringValidations.RegexMatch(value, new Regex("^[a-zA-Z0-9]{1,20}$")).Map(v => new PostalCode(v));
         }
 
         public static PostalCode CreateUnsafe(string value)

--- a/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
+++ b/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>18.0.0</PackageVersion>
+    <PackageVersion>18.1.0</PackageVersion>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
   


### PR DESCRIPTION
## Description

Fixed the Basque fiscalization postal code validations

Postal code can contain 20 alphanumeric.

## Type of change
- [x] Bug fix.
- [ ] Feature.
- [ ] Consolidation.

## Checklist
- [ ] Is breaking change.
- [ ] Documentation updated.
- [ ] Tests included (please specify cases).
