### PR TITLE
Improved GH actions 2

### DIFF
--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -6,64 +6,6 @@ on:
       - master
 
 jobs:
-  build-and-test-all:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    env:
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-      
-    defaults:
-      run:
-        working-directory: src
-        
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-
-    - name: Clean
-      run: dotnet clean ./Mews.Fiscalizations.All.sln --configuration Release && dotnet nuget locals all --clear
-        
-    - name: Install dependencies
-      run: dotnet restore
-    
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-
-    - name: Test
-      env:
-        german_api_key: ${{secrets.german_api_key}}
-        german_api_secret: ${{secrets.german_api_secret}}
-        german_admin_pin: ${{secrets.german_admin_pin}}
-
-        spanish_certificate_data: ${{secrets.spanish_certificate_data}}
-        spanish_certificate_password: ${{secrets.spanish_certificate_password}}
-        spanish_issuer_tax_number: ${{secrets.spanish_issuer_tax_number}}
-        spanish_receiver_tax_number: ${{secrets.spanish_receiver_tax_number}}
-
-        basque_araba_license: ${{secrets.basque_araba_license}}
-        basque_gipuzkoa_license: ${{secrets.basque_gipuzkoa_license}}
-
-        hungarian_login: ${{secrets.hungarian_login}}
-        hungarian_password: ${{secrets.hungarian_password}}
-        hungarian_signing_key: ${{secrets.hungarian_signing_key}}
-        hungarian_tax_payer_id: ${{secrets.hungarian_tax_payer_id}}
-        hungarian_encryption_key: ${{secrets.hungarian_encryption_key}}
-
-        italian_username: ${{secrets.italian_username}}
-        italian_password: ${{secrets.italian_password}}
-
-        austrian_user_id: ${{secrets.austrian_user_id}}
-        austrian_password: ${{secrets.austrian_password}}
-      run: dotnet test --no-restore --verbosity normal
-
   publish-all:
     runs-on: ubuntu-latest
     needs: build-and-test-all
@@ -81,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
     
     - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
 

--- a/.github/workflows/publish-austria.yml
+++ b/.github/workflows/publish-austria.yml
@@ -6,46 +6,9 @@ on:
       - master
 
 jobs:
-  build-and-test-austria:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    env:
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-      
-    defaults:
-      run:
-        working-directory: src/Austria/Mews.Fiscalizations.Austria.Tests
-        
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-
-    - name: Clean
-      run: dotnet clean ./Mews.Fiscalizations.Austria.Tests.csproj --configuration Release && dotnet nuget locals all --clear
-        
-    - name: Install dependencies
-      run: dotnet restore
-    
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-
-    - name: Test
-      env:
-        austrian_user_id: ${{secrets.austrian_user_id}}
-        austrian_password: ${{secrets.austrian_password}}
-      run: dotnet test --no-restore --verbosity normal
-
   publish-austria:
     runs-on: ubuntu-latest
-    needs: build-and-test-austria
+    needs: build-and-test-all
 
     env:
       DOTNET_NOLOGO: true
@@ -60,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
     
     - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
 

--- a/.github/workflows/publish-basque.yml
+++ b/.github/workflows/publish-basque.yml
@@ -6,49 +6,9 @@ on:
       - master
 
 jobs:
-  build-and-test-basque:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    env:
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-
-    defaults:
-      run:
-        working-directory: src/Basque/Mews.Fiscalizations.Basque.Tests
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-
-    - name: Clean
-      run: dotnet clean ./Mews.Fiscalizations.Basque.Tests.csproj --configuration Release && dotnet nuget locals all --clear
-
-    - name: Install dependencies
-      run: dotnet restore
-
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-
-    - name: Test
-      env:
-        spanish_certificate_data: ${{secrets.spanish_certificate_data}}
-        spanish_certificate_password: ${{secrets.spanish_certificate_password}}
-        spanish_issuer_tax_number: ${{secrets.spanish_issuer_tax_number}}
-        basque_araba_license: ${{secrets.basque_araba_license}}
-        basque_gipuzkoa_license: ${{secrets.basque_gipuzkoa_license}}
-      run: dotnet test --no-restore --verbosity normal
-
   publish-basque:
     runs-on: ubuntu-latest
-    needs: build-and-test-basque
+    needs: build-and-test-all
 
     env:
       DOTNET_NOLOGO: true
@@ -63,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
 

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -6,43 +6,9 @@ on:
       - master
 
 jobs:
-  build-and-test-core:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    env:
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-      
-    defaults:
-      run:
-        working-directory: src/Core/Mews.Fiscalizations.Core.Tests
-        
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-
-    - name: Clean
-      run: dotnet clean ./Mews.Fiscalizations.Core.Tests.csproj --configuration Release && dotnet nuget locals all --clear
-        
-    - name: Install dependencies
-      run: dotnet restore
-    
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
-
   publish-core:
     runs-on: ubuntu-latest
-    needs: build-and-test-core
+    needs: build-and-test-all
 
     env:
       DOTNET_NOLOGO: true
@@ -57,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
     
     - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
 

--- a/.github/workflows/publish-czechia.yml
+++ b/.github/workflows/publish-czechia.yml
@@ -6,43 +6,9 @@ on:
       - master
 
 jobs:
-  build-and-test-czechia:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    env:
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-      
-    defaults:
-      run:
-        working-directory: src/Czechia/Mews.Fiscalizations.Czechia.Tests
-        
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-
-    - name: Clean
-      run: dotnet clean ./Mews.Fiscalizations.Czechia.Tests.csproj --configuration Release && dotnet nuget locals all --clear
-        
-    - name: Install dependencies
-      run: dotnet restore
-    
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
-
   publish-czechia:
     runs-on: ubuntu-latest
-    needs: build-and-test-czechia
+    needs: build-and-test-all
 
     env:
       DOTNET_NOLOGO: true
@@ -57,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
     
     - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
 

--- a/.github/workflows/publish-germany.yml
+++ b/.github/workflows/publish-germany.yml
@@ -6,47 +6,9 @@ on:
       - master
 
 jobs:
-  build-and-test-germany:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    env:
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-      
-    defaults:
-      run:
-        working-directory: src/Germany/Mews.Fiscalizations.Germany.Tests
-        
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-
-    - name: Clean
-      run: dotnet clean ./Mews.Fiscalizations.Germany.Tests.csproj --configuration Release && dotnet nuget locals all --clear
-        
-    - name: Install dependencies
-      run: dotnet restore
-    
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-
-    - name: Test
-      env:
-        german_api_key: ${{secrets.german_api_key}}
-        german_api_secret: ${{secrets.german_api_secret}}
-        german_admin_pin: ${{secrets.german_admin_pin}}
-      run: dotnet test --no-restore --verbosity normal
-
   publish-germany:
     runs-on: ubuntu-latest
-    needs: build-and-test-germany
+    needs: build-and-test-all
 
     env:
       DOTNET_NOLOGO: true
@@ -61,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
     
     - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
 

--- a/.github/workflows/publish-hungary.yml
+++ b/.github/workflows/publish-hungary.yml
@@ -6,49 +6,9 @@ on:
       - master
 
 jobs:
-  build-and-test-hungary:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    env:
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-      
-    defaults:
-      run:
-        working-directory: src/Hungary/Mews.Fiscalizations.Hungary.Tests
-        
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-
-    - name: Clean
-      run: dotnet clean ./Mews.Fiscalizations.Hungary.Tests.csproj --configuration Release && dotnet nuget locals all --clear
-        
-    - name: Install dependencies
-      run: dotnet restore
-    
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-
-    - name: Test
-      env:
-        hungarian_login: ${{secrets.hungarian_login}}
-        hungarian_password: ${{secrets.hungarian_password}}
-        hungarian_signing_key: ${{secrets.hungarian_signing_key}}
-        hungarian_tax_payer_id: ${{secrets.hungarian_tax_payer_id}}
-        hungarian_encryption_key: ${{secrets.hungarian_encryption_key}}
-      run: dotnet test --no-restore --verbosity normal
-
   publish-hungary:
     runs-on: ubuntu-latest
-    needs: build-and-test-hungary
+    needs: build-and-test-all
 
     env:
       DOTNET_NOLOGO: true
@@ -63,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
     
     - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
 

--- a/.github/workflows/publish-italy.yml
+++ b/.github/workflows/publish-italy.yml
@@ -6,46 +6,9 @@ on:
       - master
 
 jobs:
-  build-and-test-italy:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    env:
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-      
-    defaults:
-      run:
-        working-directory: src/Italy/Mews.Fiscalizations.Italy.Tests
-        
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-
-    - name: Clean
-      run: dotnet clean ./Mews.Fiscalizations.Italy.Tests.csproj --configuration Release && dotnet nuget locals all --clear
-        
-    - name: Install dependencies
-      run: dotnet restore
-    
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-
-    - name: Test
-      env:
-        italian_username: ${{secrets.italian_username}}
-        italian_password: ${{secrets.italian_password}}
-      run: dotnet test --no-restore --verbosity normal
-
   publish-italy:
     runs-on: ubuntu-latest
-    needs: build-and-test-italy
+    needs: build-and-test-all
 
     env:
       DOTNET_NOLOGO: true
@@ -60,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
     
     - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
 

--- a/.github/workflows/publish-spain.yml
+++ b/.github/workflows/publish-spain.yml
@@ -6,48 +6,9 @@ on:
       - master
 
 jobs:
-  build-and-test-spain:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    env:
-      DOTNET_NOLOGO: true
-      DOTNET_CLI_TELEMETRY_OPTOUT: true
-      
-    defaults:
-      run:
-        working-directory: src/Spain/Mews.Fiscalizations.Spain.Tests
-        
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-
-    - name: Clean
-      run: dotnet clean ./Mews.Fiscalizations.Spain.Tests.csproj --configuration Release && dotnet nuget locals all --clear
-        
-    - name: Install dependencies
-      run: dotnet restore
-    
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-
-    - name: Test
-      env:
-        spanish_certificate_data: ${{secrets.spanish_certificate_data}}
-        spanish_certificate_password: ${{secrets.spanish_certificate_password}}
-        spanish_issuer_tax_number: ${{secrets.spanish_issuer_tax_number}}
-        spanish_receiver_tax_number: ${{secrets.spanish_receiver_tax_number}}
-      run: dotnet test --no-restore --verbosity normal
-
   publish-spain:
     runs-on: ubuntu-latest
-    needs: build-and-test-spain
+    needs: build-and-test-all
 
     env:
       DOTNET_NOLOGO: true
@@ -62,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
     
     - name: Setup .NET 6
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
 


### PR DESCRIPTION
## Description

Improved GH publish actions.

Running tests again when publish the packages doesn't bring any value, we can simply make the publish pieplines depend on the build-and-test pieplines.

Fixes #issue

## Type of change
- [ ] Bug fix.
- [ ] Feature.
- [x] Consolidation.

## Checklist
- [ ] Is breaking change.
- [ ] Documentation updated.
- [ ] Tests included (please specify cases).
