### PR TITLE
Bumped funcsharp version to use extensions for non empty string.

### DIFF
--- a/src/Mews.Fiscalizations.All.props
+++ b/src/Mews.Fiscalizations.All.props
@@ -3,6 +3,6 @@
     <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FuncSharp" Version="[7.0.0-preview.4]" />
+    <PackageReference Include="FuncSharp" Version="[7.0.0-preview.4.1]" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

It won't build until we merge the FuncSharp PR. I'll rerun the pipelines later.