### PR TITLE
Safely handling nulls as collections.

### DIFF
--- a/src/Basque/Mews.Fiscalizations.Basque/Model/Invoice/InvoiceData.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque/Model/Invoice/InvoiceData.cs
@@ -46,7 +46,7 @@ public sealed class InvoiceData
         return Try.Aggregate(
             ObjectValidations.NotNull(description),
             items.ToList().ToTry(i => i.Any() && i.Count <= 1000, _ => new Error($"{nameof(items)} count must be in range [1, 1000].")),
-            taxModes.ToTry(t => t.NonEmpty(), _ => new Error($"{nameof(taxModes)} shouldn't be empty.")),
+            taxModes.ToTry(t => t.NonEmptyNorNull(), _ => new Error($"{nameof(taxModes)} shouldn't be empty.")),
             (d, i, t) => new InvoiceData(d, i, totalAmount, t, supportWithheldAmount, tax, transactionDate)
         );
     }

--- a/src/Basque/Mews.Fiscalizations.Basque/Model/Invoice/TaxBreakdown/TaxSummary.cs
+++ b/src/Basque/Mews.Fiscalizations.Basque/Model/Invoice/TaxBreakdown/TaxSummary.cs
@@ -14,7 +14,7 @@ public sealed class TaxSummary
 
     public static Try<TaxSummary, IReadOnlyList<Error>> Create(TaxExemptItem[] taxExempt = null, TaxRateSummary[] taxed = null)
     {
-        if (taxExempt.IsEmpty() && taxed.IsEmpty())
+        if (taxExempt.IsEmptyOrNull() && taxed.IsEmptyOrNull())
         {
             return Try.Error<TaxSummary, IReadOnlyList<Error>>(new Error("Tax summary must contain at least one item.").ToEnumerable());
         }

--- a/src/Core/Mews.Fiscalizations.Core/Model/Extensions/CollectionExtensions.cs
+++ b/src/Core/Mews.Fiscalizations.Core/Model/Extensions/CollectionExtensions.cs
@@ -1,14 +1,9 @@
-﻿using System.Globalization;
+using System.Diagnostics.Contracts;
 
 namespace Mews.Fiscalizations.Core.Model;
 
 public static class CollectionExtensions
 {
-    public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer = null)
-    {
-        return new HashSet<T>(source, comparer);
-    }
-
     public static bool IsSequential<T>(this IEnumerable<T> source, Func<T, int> indexGetter, int startIndex)
     {
         return source.Select(indexGetter).IsSequential(startIndex);
@@ -17,13 +12,6 @@ public static class CollectionExtensions
     public static bool IsSequential(this IEnumerable<int> source, int startIndex)
     {
         return source.Select((value, index) => (value, index)).All(x => x.value == startIndex + x.index);
-    }
-
-    public static string MkString(this IEnumerable<string> values, string separator = "", string prefix = "", string suffix = "", bool skipEmpty = false)
-    {
-        var allItems = values.OrEmptyIfNull().Select(i => Convert.ToString(i, CultureInfo.InvariantCulture));
-        var items = skipEmpty.Match(t => allItems.Where(s => s.NonEmpty()), f => allItems);
-        return $"{prefix}{String.Join(separator, items)}{suffix}";
     }
 
     /// <summary>
@@ -37,5 +25,60 @@ public static class CollectionExtensions
         }
 
         return source;
+    }
+
+    public static bool NonEmptyNorNull<T>(this IEnumerable<T> source)
+    {
+        return source is not null && source.Any();
+    }
+
+    public static bool IsEmptyOrNull<T>(this IEnumerable<T> source)
+    {
+        return source is null || !source.Any();
+    }
+
+    [Pure]
+    public static bool NonEmptyNorNull<T>(this IReadOnlyCollection<T> source)
+    {
+        return source is not null && source.Count > 0;
+    }
+
+    [Pure]
+    public static bool IsEmptyOrNull<T>(this IReadOnlyCollection<T> source)
+    {
+        return source is null || source.Count == 0;
+    }
+
+    public static Option<T> SafeFirstOption<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+    {
+        return source is null
+            ? Option.Empty<T>()
+            : source.Where(predicate).SafeFirstOption();
+    }
+
+    public static Option<T> SafeFirstOption<T>(this IEnumerable<T> source)
+    {
+        switch (source)
+        {
+            case null:
+                return Option.Empty<T>();
+            case IReadOnlyList<T> list:
+                return list.SafeFirstOption();
+            default:
+            {
+                using var enumerator = source.GetEnumerator();
+                return enumerator.MoveNext()
+                    ? Option.Valued(enumerator.Current)
+                    : Option.Empty<T>();
+            }
+        }
+    }
+
+    [Pure]
+    public static Option<T> SafeFirstOption<T>(this IReadOnlyList<T> list)
+    {
+        return list is null || list.Count == 0
+            ? Option.Empty<T>()
+            : Option.Valued(list[0]);
     }
 }

--- a/src/Core/Mews.Fiscalizations.Core/Validations/Check.cs
+++ b/src/Core/Mews.Fiscalizations.Core/Validations/Check.cs
@@ -9,11 +9,6 @@ public static class Check
         return value ?? throw new ArgumentNullException(valueName);
     }
 
-    public static void NonEmpty<T>(IEnumerable<T> collection, string message)
-    {
-        Condition(collection.NonEmpty(), message);
-    }
-
     public static void Regex(Regex pattern, string value, string message)
     {
         Condition(pattern.IsMatch(value), message);

--- a/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/FiskalyTestFixture.cs
+++ b/src/Germany/Mews.Fiscalizations.Germany.Tests/V2/FiskalyTestFixture.cs
@@ -1,4 +1,6 @@
-﻿namespace Mews.Fiscalizations.Germany.Tests.V2;
+using Mews.Fiscalizations.Core.Model;
+
+namespace Mews.Fiscalizations.Germany.Tests.V2;
 
 /// <summary>
 /// Fiskaly limits creation of data in the test environment to 5.
@@ -14,11 +16,11 @@ public class FiskalyTestFixture
         var accessToken = (await fiskalyClient.GetAccessTokenAsync()).SuccessResult;
         var allTsses = (await fiskalyClient.GetAllEnabledTSSsAsync(accessToken)).SuccessResult;
 
-        var firstInitalizedTss = allTsses.FirstOption(t => t.State == TssState.Initialized);
+        var firstInitalizedTss = allTsses.SafeFirstOption(t => t.State == TssState.Initialized);
         TestFixture.FiskalyTestData =  await firstInitalizedTss.Match(
             async t =>
             {
-                var firstRegisteredClient = (await fiskalyClient.GetRegisteredTssClientsAsync(accessToken, t.Id)).SuccessResult.FirstOption();
+                var firstRegisteredClient = (await fiskalyClient.GetRegisteredTssClientsAsync(accessToken, t.Id)).SuccessResult.SafeFirstOption();
                 var client = await firstRegisteredClient.Match(
                     c => Task.FromResult(c),
                     async _ =>

--- a/src/Italy/Mews.Fiscalizations.Italy/Uniwix/Communication/UniwixClient.cs
+++ b/src/Italy/Mews.Fiscalizations.Italy/Uniwix/Communication/UniwixClient.cs
@@ -5,6 +5,7 @@ using Mews.Fiscalizations.Italy.Dto.Invoice;
 using Newtonsoft.Json;
 using Mews.Fiscalizations.Italy.Uniwix.Communication.Dto;
 using Mews.Fiscalizations.Italy.Uniwix.Errors;
+using Mews.Fiscalizations.Core.Model;
 
 namespace Mews.Fiscalizations.Italy.Uniwix.Communication;
 
@@ -45,7 +46,7 @@ public class UniwixClient
         var url = $"{UniwixBaseUrl}/Invoices/{fileId}";
         var result = await GetAsync<List<InvoiceStateResult>>(url);
 
-        var validatedResult = result.Where(a => a.NonEmpty(), _ => ErrorResult.Create($"Invoice {fileId} not found.", ErrorType.InvoiceNotFound));
+        var validatedResult = result.Where(a => a.NonEmptyNorNull(), _ => ErrorResult.Create($"Invoice {fileId} not found.", ErrorType.InvoiceNotFound));
         return validatedResult.Map(r =>
         {
             var state = r.OrderByDescending(s => s.Date).First();

--- a/src/Mews.Fiscalizations.All.props
+++ b/src/Mews.Fiscalizations.All.props
@@ -3,6 +3,6 @@
     <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FuncSharp" Version="[7.0.1, 8.0)" />
+    <PackageReference Include="FuncSharp" Version="[8.0.0-preview.1, 9.0)" />
   </ItemGroup>
 </Project>

--- a/src/Spain/Mews.Fiscalizations.Spain/Model/Request/TaxSummary.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Model/Request/TaxSummary.cs
@@ -14,7 +14,7 @@ public sealed class TaxSummary
 
     public static Try<TaxSummary, IReadOnlyList<Error>> Create(TaxExemptItem[] taxExempt = null, TaxRateSummary[] taxed = null)
     {
-        if (taxExempt.IsEmpty() && taxed.IsEmpty())
+        if (taxExempt.IsEmptyOrNull() && taxed.IsEmptyOrNull())
         {
             return Try.Error<TaxSummary, IReadOnlyList<Error>>(new Error("Tax summary must contain at least one item.").ToEnumerable());
         }

--- a/src/Spain/Mews.Fiscalizations.Spain/Nif/NifValidator.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Nif/NifValidator.cs
@@ -33,7 +33,7 @@ public class NifValidator
 
         return new Response(request.Contribuyente.Select(req =>
         {
-            var nifResponse = response.Contribuyente.FirstOption(res => res.Nif == req.Nif);
+            var nifResponse = response.Contribuyente.SafeFirstOption(res => res.Nif == req.Nif);
             return nifResponse.Match(
                 n =>
                 {


### PR DESCRIPTION
I made a breaking change in funcsharp. So this makes the change safe.

Updated funcsharp to latest version without safely handling nulls as collections.