### PR TITLE
EXP-2144 - Fix Fiskaly SignES API client create empty body content

### DIFF
--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/SignESApiClient.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/SignESApiClient.cs
@@ -175,7 +175,7 @@ public class SignESApiClient(HttpClient httpClient, FiskalyEnvironment environme
 
     public async Task<ResponseResult<ClientDevice>> CreateClientAsync(AccessToken token, Guid? clientId = null, CancellationToken cancellationToken = default)
     {
-        var requestBody = new StringContent(string.Empty);
+        var requestBody = new StringContent("{ }", Encoding.UTF8, JsonContentType);
 
         return await ProcessRequestAsync<ContentWrapper<ClientResponse>, ClientDevice>(
             method: HttpMethod.Put,


### PR DESCRIPTION
## Description

Fix Fiskaly SignES API client create empty body content

Fixes #issue

## Type of change
- [X] Bug fix.
- [ ] Feature.
- [ ] Consolidation.

## Checklist
- [x] Is breaking change.
- [ ] Documentation updated.
- [ ] Tests included (please specify cases).
