### PR TITLE
Support for new Tax-Identifiers in Cyprus

### DIFF
--- a/src/Core/Mews.Fiscalizations.Core.Tests/Model/Legal/TaxpayerIdentificationNumberTests.cs
+++ b/src/Core/Mews.Fiscalizations.Core.Tests/Model/Legal/TaxpayerIdentificationNumberTests.cs
@@ -7,7 +7,6 @@ public sealed class TaxpayerIdentificationNumberTests
     [TestCase("AT", "U99999999")]
     [TestCase("BE", "0999999999")]
     [TestCase("BG", "999999999")]
-    [TestCase("CY", "99999999L")]
     [TestCase("CZ", "99999999")]
     [TestCase("DE", "999999999")]
     [TestCase("DK", "99999999")]
@@ -93,5 +92,16 @@ public sealed class TaxpayerIdentificationNumberTests
     {
         var taxpayerNumber = TaxpayerIdentificationNumber.Create(Countries.Spain, taxId);
         Assert.That(taxpayerNumber.IsError);
+    }
+    
+    [Test]
+    [TestCase("CY", "99999999L")]
+    [TestCase("CY", "12345678N")]
+    public void CreatingValidCyprusTaxpayerNumberSucceeds(string countryCode, string taxpayerNumber)
+    {
+        var country = Country.GetByCode(countryCode).Get();
+        var europeanCountry = EuropeanUnionCountry.GetByCode(countryCode).Get();
+        Assert.That(EuropeanUnionTaxpayerIdentificationNumber.Create(europeanCountry, taxpayerNumber).IsSuccess);
+        Assert.That(TaxpayerIdentificationNumber.Create(country, taxpayerNumber).IsSuccess);
     }
 }

--- a/src/Core/Mews.Fiscalizations.Core/Mews.Fiscalizations.Core.csproj
+++ b/src/Core/Mews.Fiscalizations.Core/Mews.Fiscalizations.Core.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>7.0.1</PackageVersion>
+    <PackageVersion>7.0.2</PackageVersion>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 

--- a/src/Core/Mews.Fiscalizations.Core/Model/Countries/Countries.cs
+++ b/src/Core/Mews.Fiscalizations.Core/Model/Countries/Countries.cs
@@ -65,7 +65,7 @@ public static class Countries
             Croatia = NonEuropean("HR"),
             Cuba = NonEuropean("CU"),
             Curacao = NonEuropean("CW"),
-            Cyprus = European("CY", taxpayerNumberPattern: "^(CY)?[0-9]{8}L$", taxpayerNumberPatternWithoutCountryCodePrefix: "^[0-9]{8}L$"),
+            Cyprus = European("CY", taxpayerNumberPattern: "^(CY)?[0-9]{8}[A-Z]$", taxpayerNumberPatternWithoutCountryCodePrefix: "^[0-9]{8}[A-Z]$"),
             CzechRepublic = European("CZ", taxpayerNumberPattern: "^(CZ)?[0-9]{8,10}$", taxpayerNumberPatternWithoutCountryCodePrefix: "^[0-9]{8,10}$"),
             Denmark = European("DK", taxpayerNumberPattern: "^(DK)?[0-9]{8}$", taxpayerNumberPatternWithoutCountryCodePrefix: "^[0-9]{8}$"),
             Djibouti = NonEuropean("DJ"),

--- a/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
+++ b/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>37.2.2</PackageVersion>
+    <PackageVersion>37.2.3</PackageVersion>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>


### PR DESCRIPTION
## Description

This update simply extends the functionality of the Cyprus Tax Regex to use any uppercase Latin letter at the end. 


```
The Cyprus Tax Department would like to inform that the format of the
Tax Identification Number (T.I.N.) assigned to new registrations in the Cyprus 
Tax Department's Registry from March 27, 2023 onwards has been changed. 
The new Τ.Ι.Ν. format consist of:
• Nine (9) characters, with the first eight (8) being numeric and the last 
being a Latin letter (English), as the alphabetic control character. 
```
source  [New-TIN-Format-04052023.pdf](https://kkp.com.cy/wp-content/uploads/2023/07/New-TIN-Format-04052023.pdf) 


## Type of change
- [x] Bug fix.
- [ ] Feature.
- [ ] Consolidation.

## Checklist
- [ ] Is breaking change.
- [ ] Documentation updated.
- [x] Tests included (please specify cases).
