### PR TITLE
fix serialization

### DIFF
--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mews.Fiscalizations.Fiskaly.csproj
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mews.Fiscalizations.Fiskaly.csproj
@@ -10,7 +10,7 @@
         <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
         <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>2.2.2</PackageVersion>
+        <PackageVersion>2.2.3</PackageVersion>
         <LangVersion>12</LangVersion>
         <ImplicitUsings>true</ImplicitUsings>
     </PropertyGroup>

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/SignES/Invoices/Receiver.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/SignES/Invoices/Receiver.cs
@@ -6,7 +6,7 @@ public sealed class Receiver
     public string Address { get; init; }
     public string PostalCode { get; init; }
     public string TaxIdentifier { get; init; }
-    internal ReceiverType Type { get; init; }
+    public ReceiverType Type { get; init; }
     public string DocumentCountry { get; init; }
     public ForeignerDocumentType ForeignerDocumentType { get; init; }
 

--- a/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
+++ b/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>37.2.3</PackageVersion>
+    <PackageVersion>37.2.4</PackageVersion>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>


### PR DESCRIPTION
## Description

Internal property is not serialized at monolith so it leads to errors when calling Fiskaly API

Fixes #issue

## Type of change
- [X] Bug fix.
- [ ] Feature.
- [ ] Consolidation.

## Checklist
- [ ] Is breaking change.
- [ ] Documentation updated.
- [ ] Tests included (please specify cases).
