### PR TITLE
Added VAT type to support other regions

### DIFF
--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/SignES/InvoiceTests.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/SignES/InvoiceTests.cs
@@ -29,7 +29,8 @@ public class InvoiceTests
                     UnitAmount: 100,
                     FullAmount: 100,
                     TaxExemptionReason: TaxExemptionReason.OtherGrounds,
-                    TaxRate: null
+                    TaxRate: null,
+                    VatType: VatTypeEnum.IVA
                 )
             ],
             DateTime.UtcNow
@@ -56,7 +57,8 @@ public class InvoiceTests
                         UnitAmount: 1000,
                         FullAmount: 1000,
                         TaxExemptionReason: TaxExemptionReason.OtherGrounds,
-                        TaxRate: null
+                        TaxRate: null,
+                        VatType: VatTypeEnum.IVA
                     )
                 ],
                 DateTime.UtcNow
@@ -89,7 +91,8 @@ public class InvoiceTests
                         UnitAmount: 1000,
                         FullAmount: 1000,
                         TaxExemptionReason: TaxExemptionReason.OtherGrounds,
-                        TaxRate: null
+                        TaxRate: null,
+                        VatType: VatTypeEnum.IVA
                     )
                 ],
                 DateTime.UtcNow
@@ -122,7 +125,8 @@ public class InvoiceTests
                         UnitAmount: 1000,
                         FullAmount: 1000,
                         TaxExemptionReason: TaxExemptionReason.OtherGrounds,
-                        TaxRate: null
+                        TaxRate: null,
+                        VatType: VatTypeEnum.IVA
                     )
                 ],
                 DateTime.UtcNow
@@ -158,7 +162,8 @@ public class InvoiceTests
                         UnitAmount: 1000,
                         FullAmount: 1000,
                         TaxExemptionReason: TaxExemptionReason.OtherGrounds,
-                        TaxRate: null
+                        TaxRate: null,
+                        VatType: VatTypeEnum.IVA
                     )
                 ],
                 DateTime.UtcNow
@@ -194,7 +199,8 @@ public class InvoiceTests
                         UnitAmount: 1000,
                         FullAmount: 1000,
                         TaxExemptionReason: TaxExemptionReason.OtherGrounds,
-                        TaxRate: null
+                        TaxRate: null,
+                        VatType: VatTypeEnum.IVA
                     )
                 ],
                 DateTime.UtcNow
@@ -224,7 +230,8 @@ public class InvoiceTests
                         UnitAmount: 100,
                         FullAmount: 100,
                         TaxExemptionReason: TaxExemptionReason.OtherGrounds,
-                        TaxRate: null
+                        TaxRate: null,
+                        VatType: VatTypeEnum.IVA
                     )
                 ],
                 DateTime.UtcNow
@@ -268,7 +275,8 @@ public class InvoiceTests
                         UnitAmount: 1000,
                         FullAmount: 1000,
                         TaxExemptionReason: TaxExemptionReason.OtherGrounds,
-                        TaxRate: null
+                        TaxRate: null,
+                        VatType: VatTypeEnum.IVA
                     )
                 ],
                 DateTime.UtcNow
@@ -292,7 +300,8 @@ public class InvoiceTests
                         UnitAmount: 100,
                         FullAmount: 100,
                         TaxExemptionReason: TaxExemptionReason.OtherGrounds,
-                        TaxRate: null
+                        TaxRate: null,
+                        VatType: VatTypeEnum.IVA
                     )
                 ],
                 DateTime.UtcNow

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/SignES/Invoices/SimplifiedInvoiceRequest.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/SignES/Invoices/SimplifiedInvoiceRequest.cs
@@ -42,6 +42,10 @@ internal sealed class Item
 
     [JsonPropertyName("system")]
     public System System { get; init; }
+    
+    [JsonPropertyName("vat_type")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public VatTypeEnum VatType { get; init; }
 }
 
 internal sealed class System
@@ -83,4 +87,12 @@ internal enum TaxExemptionReason
     TAXABLE_EXEMPT_4,
     TAXABLE_EXEMPT_5,
     TAXABLE_EXEMPT_6
+}
+
+internal enum VatTypeEnum
+{
+    IVA,
+    IPSI,
+    IGIC,
+    OTHER
 }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/SignES/Invoices/InvoiceMapper.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/SignES/Invoices/InvoiceMapper.cs
@@ -7,6 +7,7 @@ using InvoiceState = Mews.Fiscalizations.Fiskaly.Models.SignES.Invoices.InvoiceS
 using SignedInvoiceCancellationState = Mews.Fiscalizations.Fiskaly.Models.SignES.Invoices.SignedInvoiceCancellationState;
 using SignedInvoiceRegistrationState = Mews.Fiscalizations.Fiskaly.Models.SignES.Invoices.SignedInvoiceRegistrationState;
 using TaxExemptionReason = Mews.Fiscalizations.Fiskaly.Models.SignES.Invoices.TaxExemptionReason;
+using VatTypeEnum = Mews.Fiscalizations.Fiskaly.Models.SignES.Invoices.VatTypeEnum;
 
 namespace Mews.Fiscalizations.Fiskaly.Mappers.SignES.Invoices;
 
@@ -115,6 +116,7 @@ internal static class InvoiceMapper
             Quantity = lineItem.Quantity.ToString("F2", CultureInfo.InvariantCulture),
             UnitAmount = lineItem.UnitAmount.ToString("F2", CultureInfo.InvariantCulture),
             FullAmount = lineItem.FullAmount.ToString("F2", CultureInfo.InvariantCulture),
+            VatType = MapVatType(lineItem.VatType),
             System = new DTOs.SignES.Invoices.System
             {
                 Category = category
@@ -122,6 +124,18 @@ internal static class InvoiceMapper
         };
     }
     
+    
+    private static DTOs.SignES.Invoices.VatTypeEnum MapVatType(VatTypeEnum vatType)
+    {
+        return vatType switch
+        {
+            VatTypeEnum.IVA => DTOs.SignES.Invoices.VatTypeEnum.IVA,
+            VatTypeEnum.IPSI => DTOs.SignES.Invoices.VatTypeEnum.IPSI,
+            VatTypeEnum.IGIC => DTOs.SignES.Invoices.VatTypeEnum.IGIC,
+            VatTypeEnum.OTHER => DTOs.SignES.Invoices.VatTypeEnum.OTHER,
+            _ => throw new ArgumentOutOfRangeException(nameof(vatType), vatType, null)
+        };
+    }
     private static DTOs.SignES.Invoices.TaxExemptionReason MapTaxExemptionReasonRequest(this TaxExemptionReason reason)
     {
         return reason switch

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mews.Fiscalizations.Fiskaly.csproj
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mews.Fiscalizations.Fiskaly.csproj
@@ -10,7 +10,7 @@
         <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
         <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>2.2.3</PackageVersion>
+        <PackageVersion>2.2.4</PackageVersion>
         <LangVersion>12</LangVersion>
         <ImplicitUsings>true</ImplicitUsings>
     </PropertyGroup>

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/SignES/Invoices/SimplifiedInvoice.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/SignES/Invoices/SimplifiedInvoice.cs
@@ -15,7 +15,8 @@ public sealed record InvoiceItem(
     decimal UnitAmount,
     decimal FullAmount,
     TaxExemptionReason TaxExemptionReason,
-    decimal? TaxRate
+    decimal? TaxRate,
+    VatTypeEnum VatType
 );
 
 public enum TaxExemptionReason
@@ -27,4 +28,12 @@ public enum TaxExemptionReason
     Article24,
     Article25,
     OtherGrounds
+}
+
+public enum VatTypeEnum
+{
+    IVA,
+    IPSI,
+    IGIC,
+    OTHER
 }

--- a/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
+++ b/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>37.2.5</PackageVersion>
+    <PackageVersion>37.2.6</PackageVersion>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>


### PR DESCRIPTION
## Description

Allow to select the VAT type in SignES API

Fixes #issue

## Type of change
- [ ] Bug fix.
- [X] Feature.
- [ ] Consolidation.

## Checklist
- [ ] Is breaking change.
- [ ] Documentation updated.
- [ ] Tests included (please specify cases).
