### PR TITLE
Add a counterparty spanish NIF different country

### DIFF
--- a/src/Spain/Mews.Fiscalizations.Spain.Tests/CounterPartyTests.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain.Tests/CounterPartyTests.cs
@@ -1,0 +1,65 @@
+using Mews.Fiscalizations.Core.Model;
+using Mews.Fiscalizations.Spain.Model.Request;
+using NUnit.Framework;
+
+namespace Mews.Fiscalizations.Spain.Tests;
+
+[TestFixture]
+public class CounterPartyTests
+{
+    private static readonly Name ValidName = Name.CreateUnsafe("Test Company");
+
+    [TestCase("B12345678")]
+    [TestCase("12345678A")]
+    [TestCase("A1234567B")]
+    public void ForeignCompanyWithSpanishNif_WithValidNif_Succeeds(string nif)
+    {
+        var result = CounterParty.ForeignCompanyWithSpanishNif(ValidName, nif);
+
+        Assert.That(result.IsSuccess, Is.True);
+        var counterParty = result.Success.Get();
+        counterParty.Match(
+            local =>
+            {
+                Assert.That(local.Name, Is.EqualTo(ValidName));
+                Assert.That(local.TaxpayerIdentificationNumber.TaxpayerNumber, Is.EqualTo(nif));
+            },
+            foreign => Assert.Fail("Expected LocalCounterParty but got ForeignCounterParty.")
+        );
+    }
+
+    [TestCase("")]
+    [TestCase("INVALID")]
+    [TestCase("123")]
+    public void ForeignCompanyWithSpanishNif_WithInvalidNif_Fails(string nif)
+    {
+        var result = CounterParty.ForeignCompanyWithSpanishNif(ValidName, nif);
+
+        Assert.That(result.IsSuccess, Is.False);
+    }
+
+    [TestCase("B12345678")]
+    [TestCase("12345678A")]
+    public void ForeignCompanyWithSpanishNif_ProducesSameResultAsLocal(string nif)
+    {
+        var fromLocal = CounterParty.Local(ValidName, nif);
+        var fromForeignWithSpanishNif = CounterParty.ForeignCompanyWithSpanishNif(ValidName, nif);
+
+        Assert.That(fromLocal.IsSuccess, Is.EqualTo(fromForeignWithSpanishNif.IsSuccess));
+
+        var localCounterParty = fromLocal.Success.Get();
+        var foreignWithNifCounterParty = fromForeignWithSpanishNif.Success.Get();
+
+        localCounterParty.Match(
+            local => foreignWithNifCounterParty.Match(
+                otherLocal =>
+                {
+                    Assert.That(local.Name, Is.EqualTo(otherLocal.Name));
+                    Assert.That(local.TaxpayerIdentificationNumber.TaxpayerNumber, Is.EqualTo(otherLocal.TaxpayerIdentificationNumber.TaxpayerNumber));
+                },
+                _ => Assert.Fail("Expected both to be LocalCounterParty.")
+            ),
+            _ => Assert.Fail("Expected LocalCounterParty.")
+        );
+    }
+}

--- a/src/Spain/Mews.Fiscalizations.Spain/Model/Request/CounterParty.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Model/Request/CounterParty.cs
@@ -28,4 +28,13 @@ public sealed class CounterParty : Coproduct2<LocalCounterParty, ForeignCounterP
     {
         return new CounterParty(new ForeignCounterParty(new ForeignCompany(name, taxpayerNumber)));
     }
+
+    /// <summary>
+    /// Creates a counterparty for a company based outside Spain that has been issued a Spanish NIF by the Tax Agency.
+    /// The SII API identifies such entities by their NIF, same as domestic companies.
+    /// </summary>
+    public static Try<CounterParty, Error> ForeignCompanyWithSpanishNif(Name name, string spanishNif)
+    {
+        return Local(name, spanishNif);
+    }
 }


### PR DESCRIPTION
## Description

Adds a new `CounterParty.ForeignCompanyWithSpanishNif` factory method for companies based outside Spain that have been issued a Spanish NIF by the Tax Agency. The SII API identifies such entities by their NIF the same way as domestic companies, so this method delegates to `CounterParty.Local` internally. The new method makes the intent explicit at the call site, avoiding confusion about why a foreign company would use the local counterparty path.

## Type of change
- [x] Bug fix.
- [ ] Feature.
- [ ] Consolidation.

## Checklist
- [ ] Is breaking change.
- [ ] Documentation updated.
- [x] Tests included — `CounterPartyTests` covering valid/invalid NIF inputs and equivalence with `CounterParty.Local`.