### PR TITLE
Fiskaly DSFinV-K client — auth + cash register 

### DIFF
--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -93,6 +93,8 @@ jobs:
         fiskaly_management_api_secret: ${{secrets.fiskaly_management_api_secret}}
         fiskaly_dsfinvk_api_key: ${{secrets.fiskaly_dsfinvk_api_key}}
         fiskaly_dsfinvk_api_secret: ${{secrets.fiskaly_dsfinvk_api_secret}}
+        fiskaly_dsfinvk_test_tss_id: ${{secrets.fiskaly_dsfinvk_test_tss_id}}
+        fiskaly_dsfinvk_test_client_id: ${{secrets.fiskaly_dsfinvk_test_client_id}}
       run: dotnet test --no-restore --logger "trx;LogFileName=test-results-${{ runner.os }}.trx" || true
 
     - name: Test Report

--- a/.github/workflows/build-and-test-all.yml
+++ b/.github/workflows/build-and-test-all.yml
@@ -91,6 +91,8 @@ jobs:
         fiskaly_signes_api_secret: ${{secrets.fiskaly_signes_api_secret}}
         fiskaly_management_api_key: ${{secrets.fiskaly_management_api_key}}
         fiskaly_management_api_secret: ${{secrets.fiskaly_management_api_secret}}
+        fiskaly_dsfinvk_api_key: ${{secrets.fiskaly_dsfinvk_api_key}}
+        fiskaly_dsfinvk_api_secret: ${{secrets.fiskaly_dsfinvk_api_secret}}
       run: dotnet test --no-restore --logger "trx;LogFileName=test-results-${{ runner.os }}.trx" || true
 
     - name: Test Report

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/AuthTests.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/AuthTests.cs
@@ -1,0 +1,26 @@
+using Mews.Fiscalizations.Fiskaly.APIClients;
+using NUnit.Framework;
+
+namespace Mews.Fiscalizations.Fiskaly.Tests.DSFinVK;
+
+[TestFixture]
+public class AuthTests
+{
+    private DsfinvkApiClient _client;
+
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        _client = new DsfinvkApiClient(new HttpClient(), TestFixture.DsfinvkApiKey, TestFixture.DsfinvkApiSecret);
+    }
+
+    [Test]
+    public async Task GetAccessTokenSucceeds()
+    {
+        var result = await _client.GetAccessTokenAsync();
+
+        Assert.That(result.IsSuccess);
+        Assert.That(result.SuccessResult, Is.Not.Null);
+        Assert.That(result.SuccessResult.Value, Is.Not.Empty);
+    }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/AuthTests.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/AuthTests.cs
@@ -11,6 +11,11 @@ public class AuthTests
     [OneTimeSetUp]
     public void SetUp()
     {
+        if (string.IsNullOrWhiteSpace(TestFixture.DsfinvkApiKey) || TestFixture.DsfinvkApiKey == "INSERT_API_KEY")
+        {
+            Assert.Ignore("Fiskaly DSFinV-K credentials are not configured; skipping integration test.");
+        }
+
         _client = new DsfinvkApiClient(new HttpClient(), TestFixture.DsfinvkApiKey, TestFixture.DsfinvkApiSecret);
     }
 

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashRegisterTests.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashRegisterTests.cs
@@ -1,0 +1,58 @@
+using Mews.Fiscalizations.Fiskaly.APIClients;
+using Mews.Fiscalizations.Fiskaly.Models;
+using Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashRegisters;
+using NUnit.Framework;
+
+namespace Mews.Fiscalizations.Fiskaly.Tests.DSFinVK;
+
+[TestFixture]
+public class CashRegisterTests
+{
+    private DsfinvkApiClient _client;
+    private AccessToken _accessToken;
+
+    [OneTimeSetUp]
+    public async Task SetUp()
+    {
+        if (string.IsNullOrWhiteSpace(TestFixture.DsfinvkApiKey) || TestFixture.DsfinvkApiKey == "INSERT_API_KEY"
+            || TestFixture.DsfinvkTestTssId == Guid.Empty || TestFixture.DsfinvkTestClientId == Guid.Empty)
+        {
+            Assert.Ignore("Fiskaly DSFinV-K credentials or test client/TSS ids are not configured; skipping cash register tests.");
+        }
+
+        _client = new DsfinvkApiClient(new HttpClient(), TestFixture.DsfinvkApiKey, TestFixture.DsfinvkApiSecret);
+        var tokenResult = await _client.GetAccessTokenAsync();
+        _accessToken = tokenResult.SuccessResult;
+    }
+
+    [Test]
+    public async Task UpsertCashRegisterSucceeds()
+    {
+        var cashRegister = new CashRegister(
+            ClientId: TestFixture.DsfinvkTestClientId,
+            Type: CashRegisterType.Master,
+            TssId: TestFixture.DsfinvkTestTssId,
+            SerialNumber: null,
+            Brand: "Mews",
+            Model: "Mews PMS",
+            SoftwareBrand: "Mews",
+            SoftwareVersion: "1.0.0",
+            BaseCurrencyCode: "EUR"
+        );
+
+        var result = await _client.UpsertCashRegisterAsync(_accessToken, TestFixture.DsfinvkTestClientId, cashRegister);
+
+        Assert.That(result.IsSuccess, result.ErrorResult?.Message);
+        Assert.That(result.SuccessResult.ClientId, Is.EqualTo(TestFixture.DsfinvkTestClientId));
+        Assert.That(result.SuccessResult.Type, Is.EqualTo(CashRegisterType.Master));
+    }
+
+    [Test]
+    public async Task GetCashRegisterSucceeds()
+    {
+        var result = await _client.GetCashRegisterAsync(_accessToken, TestFixture.DsfinvkTestClientId);
+
+        Assert.That(result.IsSuccess, result.ErrorResult?.Message);
+        Assert.That(result.SuccessResult.ClientId, Is.EqualTo(TestFixture.DsfinvkTestClientId));
+    }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/TestFixture.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/TestFixture.cs
@@ -6,4 +6,6 @@ public static class TestFixture
     public static readonly string SignESApiSecret = Environment.GetEnvironmentVariable("fiskaly_signes_api_secret") ?? "INSERT_API_SECRET";
     public static readonly string ManagementApiKey = Environment.GetEnvironmentVariable("fiskaly_management_api_key") ?? "INSERT_API_KEY";
     public static readonly string ManagementApiSecret = Environment.GetEnvironmentVariable("fiskaly_management_api_secret") ?? "INSERT_API_SECRET";
+    public static readonly string DsfinvkApiKey = Environment.GetEnvironmentVariable("fiskaly_dsfinvk_api_key") ?? "INSERT_API_KEY";
+    public static readonly string DsfinvkApiSecret = Environment.GetEnvironmentVariable("fiskaly_dsfinvk_api_secret") ?? "INSERT_API_SECRET";
 }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/TestFixture.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/TestFixture.cs
@@ -8,4 +8,6 @@ public static class TestFixture
     public static readonly string ManagementApiSecret = Environment.GetEnvironmentVariable("fiskaly_management_api_secret") ?? "INSERT_API_SECRET";
     public static readonly string DsfinvkApiKey = Environment.GetEnvironmentVariable("fiskaly_dsfinvk_api_key") ?? "INSERT_API_KEY";
     public static readonly string DsfinvkApiSecret = Environment.GetEnvironmentVariable("fiskaly_dsfinvk_api_secret") ?? "INSERT_API_SECRET";
+    public static readonly Guid DsfinvkTestClientId = Guid.TryParse(Environment.GetEnvironmentVariable("fiskaly_dsfinvk_test_client_id"), out var clientId) ? clientId : Guid.Empty;
+    public static readonly Guid DsfinvkTestTssId = Guid.TryParse(Environment.GetEnvironmentVariable("fiskaly_dsfinvk_test_tss_id"), out var tssId) ? tssId : Guid.Empty;
 }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/DsfinvkApiClient.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/DsfinvkApiClient.cs
@@ -8,11 +8,6 @@ using Mews.Fiscalizations.Fiskaly.Models;
 
 namespace Mews.Fiscalizations.Fiskaly.APIClients;
 
-/// <summary>
-/// Client for the Fiskaly DSFinV-K API (https://developer.fiskaly.com/api/dsfinvk/v1).
-/// This foundation covers authentication and the shared request pipeline; cash register and
-/// cash point closing operations are layered on top in later work.
-/// </summary>
 public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSecret)
 {
     // DSFinV-K exposes a single endpoint; the environment (test vs. production) is encoded in the API key itself

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/DsfinvkApiClient.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/DsfinvkApiClient.cs
@@ -1,0 +1,85 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK;
+using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.Auth;
+using Mews.Fiscalizations.Fiskaly.Mappers.DSFinVK.Auth;
+using Mews.Fiscalizations.Fiskaly.Models;
+
+namespace Mews.Fiscalizations.Fiskaly.APIClients;
+
+/// <summary>
+/// Client for the Fiskaly DSFinV-K API (https://developer.fiskaly.com/api/dsfinvk/v1).
+/// This foundation covers authentication and the shared request pipeline; cash register and
+/// cash point closing operations are layered on top in later work.
+/// </summary>
+public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSecret)
+{
+    // DSFinV-K exposes a single endpoint; the environment (test vs. production) is encoded in the API key itself
+    // and surfaced back on the access token claims.
+    private readonly Uri _baseUri = new("https://dsfinvk.fiskaly.com");
+
+    private const string RelativeApiUrl = "api/v1/";
+    private const string AuthEndpoint = "auth";
+
+    private const string AuthSchema = "Bearer";
+    private const string JsonContentType = "application/json";
+
+    public async Task<ResponseResult<AccessToken>> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+    {
+        var request = new AuthorizationTokenRequest
+        {
+            ApiKey = apiKey,
+            ApiSecret = apiSecret
+        };
+
+        return await ProcessRequestAsync<AuthorizationTokenResponse, AccessToken>(
+            method: HttpMethod.Post,
+            endpoint: AuthEndpoint,
+            request: new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, JsonContentType),
+            successFunc: r => r.MapAuthResponse(),
+            cancellationToken: cancellationToken
+        );
+    }
+
+    private async Task<ResponseResult<TResult>> ProcessRequestAsync<TDto, TResult>(
+        HttpMethod method,
+        string endpoint,
+        StringContent request,
+        Func<TDto, TResult> successFunc,
+        CancellationToken cancellationToken,
+        AccessToken token = null)
+        where TDto : class
+        where TResult : class
+    {
+        var uri = new Uri(_baseUri, $"{RelativeApiUrl}{endpoint}");
+        using var requestMessage = new HttpRequestMessage(method, uri);
+
+        if (method != HttpMethod.Get && method != HttpMethod.Delete)
+        {
+            requestMessage.Content = request;
+        }
+
+        if (token is not null)
+        {
+            requestMessage.Headers.Authorization = new AuthenticationHeaderValue(AuthSchema, token.Value);
+        }
+
+        using var httpResponse = await httpClient.SendAsync(requestMessage, cancellationToken);
+        var content = await httpResponse.Content.ReadAsStringAsync(cancellationToken);
+
+        if (httpResponse.IsSuccessStatusCode)
+        {
+            var dto = string.IsNullOrWhiteSpace(content) ? null : JsonSerializer.Deserialize<TDto>(content);
+            return new ResponseResult<TResult>(successResult: successFunc(dto));
+        }
+
+        var error = string.IsNullOrWhiteSpace(content) ? null : JsonSerializer.Deserialize<DsfinvkErrorResponse>(content);
+        return new ResponseResult<TResult>(errorResult: new ErrorResult(
+            Status: error?.StatusCode ?? (int)httpResponse.StatusCode,
+            Code: null,
+            Error: error?.Error,
+            Message: error?.Message
+        ));
+    }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/DsfinvkApiClient.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/DsfinvkApiClient.cs
@@ -1,10 +1,14 @@
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK;
 using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.Auth;
+using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashRegisters;
 using Mews.Fiscalizations.Fiskaly.Mappers.DSFinVK.Auth;
+using Mews.Fiscalizations.Fiskaly.Mappers.DSFinVK.CashRegisters;
 using Mews.Fiscalizations.Fiskaly.Models;
+using Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashRegisters;
 
 namespace Mews.Fiscalizations.Fiskaly.APIClients;
 
@@ -16,6 +20,7 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
 
     private const string RelativeApiUrl = "api/v1/";
     private const string AuthEndpoint = "auth";
+    private const string CashRegistersEndpoint = "cash_registers";
 
     private const string AuthSchema = "Bearer";
     private const string JsonContentType = "application/json";
@@ -33,6 +38,45 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
             endpoint: AuthEndpoint,
             request: new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, JsonContentType),
             successFunc: r => r.MapAuthResponse(),
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public async Task<ResponseResult<CashRegister>> UpsertCashRegisterAsync(
+        AccessToken token,
+        Guid clientId,
+        CashRegister cashRegister,
+        CancellationToken cancellationToken = default)
+    {
+        var requestBody = new StringContent(
+            JsonSerializer.Serialize(CashRegisterMapper.MapUpsertRequest(cashRegister), new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            }),
+            Encoding.UTF8,
+            JsonContentType);
+
+        return await ProcessRequestAsync<CashRegisterResponse, CashRegister>(
+            method: HttpMethod.Put,
+            endpoint: $"{CashRegistersEndpoint}/{clientId}",
+            request: requestBody,
+            successFunc: r => r.MapResponse(),
+            token: token,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public async Task<ResponseResult<CashRegister>> GetCashRegisterAsync(
+        AccessToken token,
+        Guid clientId,
+        CancellationToken cancellationToken = default)
+    {
+        return await ProcessRequestAsync<CashRegisterResponse, CashRegister>(
+            method: HttpMethod.Get,
+            endpoint: $"{CashRegistersEndpoint}/{clientId}",
+            request: null,
+            successFunc: r => r.MapResponse(),
+            token: token,
             cancellationToken: cancellationToken
         );
     }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/Auth/AuthorizationTokenRequest.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/Auth/AuthorizationTokenRequest.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.Auth;
+
+internal sealed class AuthorizationTokenRequest
+{
+    [JsonPropertyName("api_key")]
+    public string ApiKey { get; init; }
+
+    [JsonPropertyName("api_secret")]
+    public string ApiSecret { get; init; }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/Auth/AuthorizationTokenResponse.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/Auth/AuthorizationTokenResponse.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.Auth;
+
+internal sealed class AuthorizationTokenResponse
+{
+    [JsonPropertyName("access_token")]
+    public string AccessToken { get; init; }
+
+    [JsonPropertyName("access_token_claims")]
+    public AccessTokenClaims AccessTokenClaims { get; init; }
+
+    [JsonPropertyName("access_token_expires_at")]
+    public long AccessTokenExpiresAt { get; init; }
+}
+
+internal sealed class AccessTokenClaims
+{
+    [JsonPropertyName("env")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public FiskalyEnvironment Environment { get; init; }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashRegisters/CashRegisterResponse.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashRegisters/CashRegisterResponse.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashRegisters;
+
+internal sealed class CashRegisterResponse
+{
+    [JsonPropertyName("client_id")]
+    public Guid ClientId { get; init; }
+
+    [JsonPropertyName("cash_register_type")]
+    public string CashRegisterType { get; init; }
+
+    [JsonPropertyName("tss_id")]
+    public Guid TssId { get; init; }
+
+    [JsonPropertyName("serial_number")]
+    public string SerialNumber { get; init; }
+
+    [JsonPropertyName("brand")]
+    public string Brand { get; init; }
+
+    [JsonPropertyName("model")]
+    public string Model { get; init; }
+
+    [JsonPropertyName("software")]
+    public CashRegisterSoftware Software { get; init; }
+
+    [JsonPropertyName("base_currency_code")]
+    public string BaseCurrencyCode { get; init; }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashRegisters/UpsertCashRegisterRequest.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashRegisters/UpsertCashRegisterRequest.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashRegisters;
+
+internal sealed class UpsertCashRegisterRequest
+{
+    [JsonPropertyName("cash_register_type")]
+    public CashRegisterTypeRequest CashRegisterType { get; init; }
+
+    [JsonPropertyName("brand")]
+    public string Brand { get; init; }
+
+    [JsonPropertyName("model")]
+    public string Model { get; init; }
+
+    [JsonPropertyName("software")]
+    public CashRegisterSoftware Software { get; init; }
+
+    [JsonPropertyName("base_currency_code")]
+    public string BaseCurrencyCode { get; init; }
+}
+
+internal sealed class CashRegisterTypeRequest
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; }
+
+    [JsonPropertyName("tss_id")]
+    public Guid TssId { get; init; }
+}
+
+internal sealed class CashRegisterSoftware
+{
+    [JsonPropertyName("brand")]
+    public string Brand { get; init; }
+
+    [JsonPropertyName("version")]
+    public string Version { get; init; }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/DsfinvkErrorResponse.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/DsfinvkErrorResponse.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK;
+
+internal sealed class DsfinvkErrorResponse
+{
+    [JsonPropertyName("status_code")]
+    public int? StatusCode { get; init; }
+
+    [JsonPropertyName("error")]
+    public string Error { get; init; }
+
+    [JsonPropertyName("message")]
+    public string Message { get; init; }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/Auth/AuthMapper.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/Auth/AuthMapper.cs
@@ -1,0 +1,19 @@
+using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.Auth;
+using Mews.Fiscalizations.Fiskaly.Models;
+using FiskalyEnvironmentDto = Mews.Fiscalizations.Fiskaly.DTOs.FiskalyEnvironment;
+
+namespace Mews.Fiscalizations.Fiskaly.Mappers.DSFinVK.Auth;
+
+internal static class AuthMapper
+{
+    public static AccessToken MapAuthResponse(this AuthorizationTokenResponse response)
+    {
+        return new AccessToken(
+            value: response.AccessToken,
+            environment: response.AccessTokenClaims.Environment == FiskalyEnvironmentDto.TEST
+                ? FiskalyEnvironment.Test
+                : FiskalyEnvironment.Production,
+            expirationUtc: DateTimeOffset.FromUnixTimeSeconds(response.AccessTokenExpiresAt).DateTime
+        );
+    }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashRegisters/CashRegisterMapper.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashRegisters/CashRegisterMapper.cs
@@ -1,0 +1,60 @@
+using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashRegisters;
+using Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashRegisters;
+
+namespace Mews.Fiscalizations.Fiskaly.Mappers.DSFinVK.CashRegisters;
+
+internal static class CashRegisterMapper
+{
+    public static UpsertCashRegisterRequest MapUpsertRequest(CashRegister cashRegister)
+    {
+        return new UpsertCashRegisterRequest
+        {
+            CashRegisterType = new CashRegisterTypeRequest
+            {
+                Type = MapCashRegisterType(cashRegister.Type),
+                TssId = cashRegister.TssId
+            },
+            Brand = cashRegister.Brand,
+            Model = cashRegister.Model,
+            Software = new CashRegisterSoftware
+            {
+                Brand = cashRegister.SoftwareBrand,
+                Version = cashRegister.SoftwareVersion
+            },
+            BaseCurrencyCode = cashRegister.BaseCurrencyCode
+        };
+    }
+
+    public static CashRegister MapResponse(this CashRegisterResponse response)
+    {
+        return new CashRegister(
+            ClientId: response.ClientId,
+            Type: MapCashRegisterTypeResponse(response.CashRegisterType),
+            TssId: response.TssId,
+            SerialNumber: response.SerialNumber,
+            Brand: response.Brand,
+            Model: response.Model,
+            SoftwareBrand: response.Software.Brand,
+            SoftwareVersion: response.Software.Version,
+            BaseCurrencyCode: response.BaseCurrencyCode
+        );
+    }
+
+    private static string MapCashRegisterType(CashRegisterType type)
+    {
+        return type switch
+        {
+            CashRegisterType.Master => "MASTER",
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+        };
+    }
+
+    private static CashRegisterType MapCashRegisterTypeResponse(string type)
+    {
+        return type switch
+        {
+            "MASTER" => CashRegisterType.Master,
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+        };
+    }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mews.Fiscalizations.Fiskaly.csproj
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mews.Fiscalizations.Fiskaly.csproj
@@ -9,7 +9,7 @@
         <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
         <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>2.2.8</PackageVersion>
+        <PackageVersion>2.3.0</PackageVersion>
         <LangVersion>12</LangVersion>
         <ImplicitUsings>true</ImplicitUsings>
     </PropertyGroup>

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashRegisters/CashRegister.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashRegisters/CashRegister.cs
@@ -1,0 +1,18 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashRegisters;
+
+public sealed record CashRegister(
+    Guid ClientId,
+    CashRegisterType Type,
+    Guid TssId,
+    string SerialNumber,
+    string Brand,
+    string Model,
+    string SoftwareBrand,
+    string SoftwareVersion,
+    string BaseCurrencyCode
+);
+
+public enum CashRegisterType
+{
+    Master
+}

--- a/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
+++ b/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>37.2.13</PackageVersion>
+    <PackageVersion>37.3.0</PackageVersion>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>


### PR DESCRIPTION
## Release note
Add the Fiskaly DSFinV-K client (authentication + cash register) to `Mews.Fiscalizations.Fiskaly`.

---

## Summary
- Adds the DSFinV-K Fiskaly API client to `Mews.Fiscalizations.Fiskaly`, alongside the existing SignES / Management clients: authentication + the shared request pipeline, and cash register upsert/get.
- First step of moving the Germany DSFinV-K integration off the standalone `fiscalization-service` and into the shared fiscalization library the monolith consumes.
- Bumps `Mews.Fiscalizations.Fiskaly` to 2.3.0 and `Mews.Fiscalizations.All` to 37.3.0 so the new client reaches consumers.
- Covers EXP-4391 (client foundation) and EXP-4393 (cash register, library side).

---

## Testing steps
- Integration tests (`AuthTests`, `CashRegisterTests`) run against the Fiskaly DSFinV-K test environment.
- They self-skip when credentials/ids are absent. To run them, set `fiskaly_dsfinvk_api_key` / `fiskaly_dsfinvk_api_secret` (and `fiskaly_dsfinvk_test_client_id` / `fiskaly_dsfinvk_test_tss_id` for the cash register tests) and run the Fiskaly test project.

---

## Test coverage
New auth + cash register paths are covered by integration tests against the real DSFinV-K test API. They skip cleanly without credentials so CI stays green until the repo secrets are provisioned.

---

## Feature flag
N/A — additive library code with no behaviour change for existing consumers. The DSFinV-K client is exercised only once a consumer (the monolith) calls it, behind that consumer's own platform flag.

---

## Critical User Journeys / Golden Paths
N/A — new, currently-unconsumed client surface; does not touch the existing SignES / Management / Germany SIGN DE paths.

---

## Database changes
N/A — library only.

---

## Performance & Security & Data Privacy
- Observability: Fiskaly calls return a typed `ResponseResult` / `ErrorResult` the consumer logs; the environment is taken from the access-token claims.
- Blast radius: additive to the shared `Mews.Fiscalizations.Fiskaly` / `Mews.Fiscalizations.All` packages; no existing types changed.
- Rollback: revert the package bump; there are no runtime consumers until the monolith opts in.

---

## Follow-up issues
- Provision `fiskaly_dsfinvk_api_key` / `_secret` (+ test client/TSS ids) as repo secrets so the integration tests actually execute in CI.
- Cash point closing client (insert/get/delete) + payload models land on top of this in EXP-4394 (ST-04).
