### PR TITLE
EXP-4394: DSFinV-K cash point closing client (insert/get/delete)

### DIFF
--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/AuthTests.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/AuthTests.cs
@@ -11,11 +11,6 @@ public class AuthTests
     [OneTimeSetUp]
     public void SetUp()
     {
-        if (string.IsNullOrWhiteSpace(TestFixture.DsfinvkApiKey) || TestFixture.DsfinvkApiKey == "INSERT_API_KEY")
-        {
-            Assert.Ignore("Fiskaly DSFinV-K credentials are not configured; skipping integration test.");
-        }
-
         _client = new DsfinvkApiClient(new HttpClient(), TestFixture.DsfinvkApiKey, TestFixture.DsfinvkApiSecret);
     }
 

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashPointClosingTests.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashPointClosingTests.cs
@@ -82,11 +82,7 @@ public class CashPointClosingTests
                     Storno: false,
                     BusinessTransactionType: BusinessTransactionType.Umsatz,
                     BusinessCaseAmountsPerVat: amountsPerVat,
-                    ItemText: "Room",
-                    Quantity: 1m,
-                    PricePerUnit: 100.00m,
-                    GrossAmount: 119.00m,
-                    NetAmount: 100.00m
+                    ItemText: "Room"
                 )
             },
             AmountsPerVat: amountsPerVat,

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashPointClosingTests.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashPointClosingTests.cs
@@ -15,7 +15,11 @@ public class CashPointClosingTests
     [OneTimeSetUp]
     public async Task SetUp()
     {
-        _client = new DsfinvkApiClient(new HttpClient(), TestFixture.DsfinvkApiKey, TestFixture.DsfinvkApiSecret);
+        _client = new DsfinvkApiClient(
+            new HttpClient(),
+            TestFixture.DsfinvkApiKey,
+            TestFixture.DsfinvkApiSecret
+        );
         var tokenResult = await _client.GetAccessTokenAsync();
         _accessToken = tokenResult.SuccessResult;
 
@@ -30,14 +34,28 @@ public class CashPointClosingTests
         var closing = BuildTestClosing(exportId: Math.Abs(Guid.NewGuid().GetHashCode()));
         var result = await _client.InsertCashPointClosingAsync(_accessToken, closing);
 
-        Assert.That(result.IsSuccess, $"[{result.ErrorResult?.Status}] {result.ErrorResult?.Error} :: {result.ErrorResult?.Message}");
-        Assert.That(result.SuccessResult.State, Is.AnyOf(CashPointClosingState.Pending, CashPointClosingState.Working, CashPointClosingState.Completed));
+        Assert.That(
+            result.IsSuccess,
+            $"[{result.ErrorResult?.Status}] {result.ErrorResult?.Error} :: {result.ErrorResult?.Message}"
+        );
+        Assert.That(
+            result.SuccessResult.State,
+            Is.AnyOf(
+                CashPointClosingState.Pending,
+                CashPointClosingState.Working,
+                CashPointClosingState.Completed
+            )
+        );
     }
 
     [Test]
     public async Task GetCashPointClosingSucceeds()
     {
-        Assert.That(_insertedClosingId, Is.Not.EqualTo(Guid.Empty), "Setup failed to insert a closing.");
+        Assert.That(
+            _insertedClosingId,
+            Is.Not.EqualTo(Guid.Empty),
+            "Setup failed to insert a closing."
+        );
 
         var result = await _client.GetCashPointClosingAsync(_accessToken, _insertedClosingId);
 
@@ -51,7 +69,10 @@ public class CashPointClosingTests
     {
         var closing = BuildTestClosing(exportId: Math.Abs(Guid.NewGuid().GetHashCode()));
         var insertResult = await _client.InsertCashPointClosingAsync(_accessToken, closing);
-        Assert.That(insertResult.IsSuccess, "Insert before delete failed: " + insertResult.ErrorResult?.Message);
+        Assert.That(
+            insertResult.IsSuccess,
+            "Insert before delete failed: " + insertResult.ErrorResult?.Message
+        );
 
         var result = await _client.DeleteCashPointClosingAsync(_accessToken, closing.ClosingId);
 
@@ -62,7 +83,12 @@ public class CashPointClosingTests
     {
         var amountsPerVat = new[]
         {
-            new AmountPerVat(VatDefinitionExportId: 1, GrossAmount: 119.00m, NetAmount: 100.00m, TaxAmount: 19.00m)
+            new AmountPerVat(
+                VatDefinitionExportId: 1,
+                GrossAmount: 119.00m,
+                NetAmount: 100.00m,
+                TaxAmount: 19.00m
+            ),
         };
 
         var transaction = new CashPointClosingTransaction(
@@ -83,7 +109,7 @@ public class CashPointClosingTests
                     BusinessTransactionType: BusinessTransactionType.Umsatz,
                     BusinessCaseAmountsPerVat: amountsPerVat,
                     ItemText: "Room"
-                )
+                ),
             },
             AmountsPerVat: amountsPerVat,
             PaymentTypes: new[] { new PaymentTypeAmount("Unbar", 119.00m, "EUR") },
@@ -96,11 +122,13 @@ public class CashPointClosingTests
             CashPointClosingExportId: exportId,
             ExportCreationDate: DateTimeOffset.UtcNow,
             BusinessDate: DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)),
+            FirstTransactionExportId: transaction.TransactionExportId,
+            LastTransactionExportId: transaction.TransactionExportId,
             Transactions: new[] { transaction },
             CashStatement: new CashStatement(
                 BusinessCases: new[]
                 {
-                    new BusinessCaseSummary(BusinessTransactionType.Umsatz, amountsPerVat)
+                    new BusinessCaseSummary(BusinessTransactionType.Umsatz, amountsPerVat),
                 },
                 Payment: new CashStatementPayment(
                     FullAmount: 119.00m,

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashPointClosingTests.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashPointClosingTests.cs
@@ -112,7 +112,7 @@ public class CashPointClosingTests
                 ),
             },
             AmountsPerVat: amountsPerVat,
-            PaymentTypes: new[] { new PaymentTypeAmount("Unbar", 119.00m, "EUR") },
+            PaymentTypes: new[] { new PaymentTypeAmount(PaymentType.NonCash, 119.00m, "EUR") },
             Security: new TransactionSecurity(TssTxId: Guid.NewGuid())
         );
 
@@ -134,7 +134,10 @@ public class CashPointClosingTests
                     FullAmount: 119.00m,
                     CashAmount: 0m,
                     CashAmountsByCurrency: Enumerable.Empty<CurrencyAmount>(),
-                    PaymentTypes: new[] { new PaymentTypeAmount("Unbar", 119.00m, "EUR") }
+                    PaymentTypes: new[]
+                    {
+                        new PaymentTypeAmount(PaymentType.NonCash, 119.00m, "EUR"),
+                    }
                 )
             )
         );

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashPointClosingTests.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashPointClosingTests.cs
@@ -1,0 +1,118 @@
+using Mews.Fiscalizations.Fiskaly.APIClients;
+using Mews.Fiscalizations.Fiskaly.Models;
+using Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+using NUnit.Framework;
+
+namespace Mews.Fiscalizations.Fiskaly.Tests.DSFinVK;
+
+[TestFixture]
+public class CashPointClosingTests
+{
+    private DsfinvkApiClient _client;
+    private AccessToken _accessToken;
+    private Guid _insertedClosingId;
+
+    [OneTimeSetUp]
+    public async Task SetUp()
+    {
+        _client = new DsfinvkApiClient(new HttpClient(), TestFixture.DsfinvkApiKey, TestFixture.DsfinvkApiSecret);
+        var tokenResult = await _client.GetAccessTokenAsync();
+        _accessToken = tokenResult.SuccessResult;
+
+        var closing = BuildTestClosing(exportId: Math.Abs(Guid.NewGuid().GetHashCode()));
+        var insertResult = await _client.InsertCashPointClosingAsync(_accessToken, closing);
+        _insertedClosingId = insertResult.IsSuccess ? closing.ClosingId : Guid.Empty;
+    }
+
+    [Test]
+    public async Task InsertCashPointClosingSucceeds()
+    {
+        var closing = BuildTestClosing(exportId: Math.Abs(Guid.NewGuid().GetHashCode()));
+        var result = await _client.InsertCashPointClosingAsync(_accessToken, closing);
+
+        Assert.That(result.IsSuccess, $"[{result.ErrorResult?.Status}] {result.ErrorResult?.Error} :: {result.ErrorResult?.Message}");
+        Assert.That(result.SuccessResult.State, Is.AnyOf(CashPointClosingState.Pending, CashPointClosingState.Working, CashPointClosingState.Completed));
+    }
+
+    [Test]
+    public async Task GetCashPointClosingSucceeds()
+    {
+        Assert.That(_insertedClosingId, Is.Not.EqualTo(Guid.Empty), "Setup failed to insert a closing.");
+
+        var result = await _client.GetCashPointClosingAsync(_accessToken, _insertedClosingId);
+
+        Assert.That(result.IsSuccess, result.ErrorResult?.Message);
+        Assert.That(result.SuccessResult.Id, Is.EqualTo(_insertedClosingId));
+        Assert.That(result.SuccessResult.ClientId, Is.EqualTo(TestFixture.DsfinvkTestClientId));
+    }
+
+    [Test]
+    public async Task DeleteCashPointClosingSucceeds()
+    {
+        var closing = BuildTestClosing(exportId: Math.Abs(Guid.NewGuid().GetHashCode()));
+        var insertResult = await _client.InsertCashPointClosingAsync(_accessToken, closing);
+        Assert.That(insertResult.IsSuccess, "Insert before delete failed: " + insertResult.ErrorResult?.Message);
+
+        var result = await _client.DeleteCashPointClosingAsync(_accessToken, closing.ClosingId);
+
+        Assert.That(result.IsSuccess, result.ErrorResult?.Message);
+    }
+
+    private static CashPointClosing BuildTestClosing(long exportId)
+    {
+        var amountsPerVat = new[]
+        {
+            new AmountPerVat(VatDefinitionExportId: 1, GrossAmount: 119.00m, NetAmount: 100.00m, TaxAmount: 19.00m)
+        };
+
+        var transaction = new CashPointClosingTransaction(
+            TxId: Guid.NewGuid(),
+            TransactionExportId: $"MEWS-{exportId}",
+            Number: exportId,
+            TimestampStart: DateTimeOffset.UtcNow.AddMinutes(-5),
+            TimestampEnd: DateTimeOffset.UtcNow,
+            Storno: false,
+            ProcessType: ProcessType.Receipt,
+            ClosingClientId: TestFixture.DsfinvkTestClientId,
+            FullAmountInclVat: 119.00m,
+            Lines: new[]
+            {
+                new TransactionLine(
+                    LineItemExportId: "1",
+                    Storno: false,
+                    BusinessTransactionType: BusinessTransactionType.Umsatz,
+                    BusinessCaseAmountsPerVat: amountsPerVat,
+                    ItemText: "Room",
+                    Quantity: 1m,
+                    PricePerUnit: 100.00m,
+                    GrossAmount: 119.00m,
+                    NetAmount: 100.00m
+                )
+            },
+            AmountsPerVat: amountsPerVat,
+            PaymentTypes: new[] { new PaymentTypeAmount("Unbar", 119.00m, "EUR") },
+            Security: new TransactionSecurity(TssTxId: Guid.NewGuid())
+        );
+
+        return new CashPointClosing(
+            ClosingId: Guid.NewGuid(),
+            ClientId: TestFixture.DsfinvkTestClientId,
+            CashPointClosingExportId: exportId,
+            ExportCreationDate: DateTimeOffset.UtcNow,
+            BusinessDate: DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)),
+            Transactions: new[] { transaction },
+            CashStatement: new CashStatement(
+                BusinessCases: new[]
+                {
+                    new BusinessCaseSummary(BusinessTransactionType.Umsatz, amountsPerVat)
+                },
+                Payment: new CashStatementPayment(
+                    FullAmount: 119.00m,
+                    CashAmount: 0m,
+                    CashAmountsByCurrency: Enumerable.Empty<CurrencyAmount>(),
+                    PaymentTypes: new[] { new PaymentTypeAmount("Unbar", 119.00m, "EUR") }
+                )
+            )
+        );
+    }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashRegisterTests.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashRegisterTests.cs
@@ -14,33 +14,18 @@ public class CashRegisterTests
     [OneTimeSetUp]
     public async Task SetUp()
     {
-        if (string.IsNullOrWhiteSpace(TestFixture.DsfinvkApiKey) || TestFixture.DsfinvkApiKey == "INSERT_API_KEY"
-            || TestFixture.DsfinvkTestTssId == Guid.Empty || TestFixture.DsfinvkTestClientId == Guid.Empty)
-        {
-            Assert.Ignore("Fiskaly DSFinV-K credentials or test client/TSS ids are not configured; skipping cash register tests.");
-        }
-
         _client = new DsfinvkApiClient(new HttpClient(), TestFixture.DsfinvkApiKey, TestFixture.DsfinvkApiSecret);
         var tokenResult = await _client.GetAccessTokenAsync();
         _accessToken = tokenResult.SuccessResult;
+
+        // Ensure the cash register exists so GetCashRegisterSucceeds does not depend on test execution order.
+        await _client.UpsertCashRegisterAsync(_accessToken, TestFixture.DsfinvkTestClientId, CreateCashRegister());
     }
 
     [Test]
     public async Task UpsertCashRegisterSucceeds()
     {
-        var cashRegister = new CashRegister(
-            ClientId: TestFixture.DsfinvkTestClientId,
-            Type: CashRegisterType.Master,
-            TssId: TestFixture.DsfinvkTestTssId,
-            SerialNumber: null,
-            Brand: "Mews",
-            Model: "Mews PMS",
-            SoftwareBrand: "Mews",
-            SoftwareVersion: "1.0.0",
-            BaseCurrencyCode: "EUR"
-        );
-
-        var result = await _client.UpsertCashRegisterAsync(_accessToken, TestFixture.DsfinvkTestClientId, cashRegister);
+        var result = await _client.UpsertCashRegisterAsync(_accessToken, TestFixture.DsfinvkTestClientId, CreateCashRegister());
 
         Assert.That(result.IsSuccess, result.ErrorResult?.Message);
         Assert.That(result.SuccessResult.ClientId, Is.EqualTo(TestFixture.DsfinvkTestClientId));
@@ -54,5 +39,20 @@ public class CashRegisterTests
 
         Assert.That(result.IsSuccess, result.ErrorResult?.Message);
         Assert.That(result.SuccessResult.ClientId, Is.EqualTo(TestFixture.DsfinvkTestClientId));
+    }
+
+    private static CashRegister CreateCashRegister()
+    {
+        return new CashRegister(
+            ClientId: TestFixture.DsfinvkTestClientId,
+            Type: CashRegisterType.Master,
+            TssId: TestFixture.DsfinvkTestTssId,
+            SerialNumber: null,
+            Brand: "Mews",
+            Model: "Mews PMS",
+            SoftwareBrand: "Mews",
+            SoftwareVersion: "1.0.0",
+            BaseCurrencyCode: "EUR"
+        );
     }
 }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/DsfinvkApiClient.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/DsfinvkApiClient.cs
@@ -4,10 +4,13 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK;
 using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.Auth;
+using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings;
 using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashRegisters;
 using Mews.Fiscalizations.Fiskaly.Mappers.DSFinVK.Auth;
+using Mews.Fiscalizations.Fiskaly.Mappers.DSFinVK.CashPointClosings;
 using Mews.Fiscalizations.Fiskaly.Mappers.DSFinVK.CashRegisters;
 using Mews.Fiscalizations.Fiskaly.Models;
+using Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
 using Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashRegisters;
 
 namespace Mews.Fiscalizations.Fiskaly.APIClients;
@@ -21,6 +24,7 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
     private const string RelativeApiUrl = "api/v1/";
     private const string AuthEndpoint = "auth";
     private const string CashRegistersEndpoint = "cash_registers";
+    private const string CashPointClosingsEndpoint = "cash_point_closings";
 
     private const string AuthSchema = "Bearer";
     private const string JsonContentType = "application/json";
@@ -76,6 +80,59 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
             endpoint: $"{CashRegistersEndpoint}/{clientId}",
             request: null,
             successFunc: r => r.MapResponse(),
+            token: token,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public async Task<ResponseResult<CashPointClosingResult>> InsertCashPointClosingAsync(
+        AccessToken token,
+        CashPointClosing closing,
+        CancellationToken cancellationToken = default)
+    {
+        var requestBody = new StringContent(
+            JsonSerializer.Serialize(CashPointClosingMapper.MapInsertRequest(closing), new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            }),
+            Encoding.UTF8,
+            JsonContentType);
+
+        return await ProcessRequestAsync<CashPointClosingResponse, CashPointClosingResult>(
+            method: HttpMethod.Put,
+            endpoint: $"{CashPointClosingsEndpoint}/{closing.ClosingId}",
+            request: requestBody,
+            successFunc: r => r.MapResponse(),
+            token: token,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public async Task<ResponseResult<CashPointClosingResult>> GetCashPointClosingAsync(
+        AccessToken token,
+        Guid closingId,
+        CancellationToken cancellationToken = default)
+    {
+        return await ProcessRequestAsync<CashPointClosingResponse, CashPointClosingResult>(
+            method: HttpMethod.Get,
+            endpoint: $"{CashPointClosingsEndpoint}/{closingId}",
+            request: null,
+            successFunc: r => r.MapResponse(),
+            token: token,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public async Task<ResponseResult<CashPointClosingResult>> DeleteCashPointClosingAsync(
+        AccessToken token,
+        Guid closingId,
+        CancellationToken cancellationToken = default)
+    {
+        return await ProcessRequestAsync<CashPointClosingResponse, CashPointClosingResult>(
+            method: HttpMethod.Delete,
+            endpoint: $"{CashPointClosingsEndpoint}/{closingId}",
+            request: null,
+            successFunc: _ => null,
             token: token,
             cancellationToken: cancellationToken
         );

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/DsfinvkApiClient.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/DsfinvkApiClient.cs
@@ -29,18 +29,20 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
     private const string AuthSchema = "Bearer";
     private const string JsonContentType = "application/json";
 
-    public async Task<ResponseResult<AccessToken>> GetAccessTokenAsync(CancellationToken cancellationToken = default)
+    public async Task<ResponseResult<AccessToken>> GetAccessTokenAsync(
+        CancellationToken cancellationToken = default
+    )
     {
-        var request = new AuthorizationTokenRequest
-        {
-            ApiKey = apiKey,
-            ApiSecret = apiSecret
-        };
+        var request = new AuthorizationTokenRequest { ApiKey = apiKey, ApiSecret = apiSecret };
 
         return await ProcessRequestAsync<AuthorizationTokenResponse, AccessToken>(
             method: HttpMethod.Post,
             endpoint: AuthEndpoint,
-            request: new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, JsonContentType),
+            request: new StringContent(
+                JsonSerializer.Serialize(request),
+                Encoding.UTF8,
+                JsonContentType
+            ),
             successFunc: r => r.MapAuthResponse(),
             cancellationToken: cancellationToken
         );
@@ -50,15 +52,20 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
         AccessToken token,
         Guid clientId,
         CashRegister cashRegister,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var requestBody = new StringContent(
-            JsonSerializer.Serialize(CashRegisterMapper.MapUpsertRequest(cashRegister), new JsonSerializerOptions
-            {
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-            }),
+            JsonSerializer.Serialize(
+                CashRegisterMapper.MapUpsertRequest(cashRegister),
+                new JsonSerializerOptions
+                {
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                }
+            ),
             Encoding.UTF8,
-            JsonContentType);
+            JsonContentType
+        );
 
         return await ProcessRequestAsync<CashRegisterResponse, CashRegister>(
             method: HttpMethod.Put,
@@ -73,7 +80,8 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
     public async Task<ResponseResult<CashRegister>> GetCashRegisterAsync(
         AccessToken token,
         Guid clientId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         return await ProcessRequestAsync<CashRegisterResponse, CashRegister>(
             method: HttpMethod.Get,
@@ -88,15 +96,20 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
     public async Task<ResponseResult<CashPointClosingResult>> InsertCashPointClosingAsync(
         AccessToken token,
         CashPointClosing closing,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var requestBody = new StringContent(
-            JsonSerializer.Serialize(CashPointClosingMapper.MapInsertRequest(closing), new JsonSerializerOptions
-            {
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-            }),
+            JsonSerializer.Serialize(
+                CashPointClosingMapper.MapInsertRequest(closing),
+                new JsonSerializerOptions
+                {
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                }
+            ),
             Encoding.UTF8,
-            JsonContentType);
+            JsonContentType
+        );
 
         return await ProcessRequestAsync<CashPointClosingResponse, CashPointClosingResult>(
             method: HttpMethod.Put,
@@ -111,7 +124,8 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
     public async Task<ResponseResult<CashPointClosingResult>> GetCashPointClosingAsync(
         AccessToken token,
         Guid closingId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         return await ProcessRequestAsync<CashPointClosingResponse, CashPointClosingResult>(
             method: HttpMethod.Get,
@@ -126,7 +140,8 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
     public async Task<ResponseResult<CashPointClosingResult>> DeleteCashPointClosingAsync(
         AccessToken token,
         Guid closingId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         return await ProcessRequestAsync<CashPointClosingResponse, CashPointClosingResult>(
             method: HttpMethod.Delete,
@@ -144,7 +159,8 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
         StringContent request,
         Func<TDto, TResult> successFunc,
         CancellationToken cancellationToken,
-        AccessToken token = null)
+        AccessToken token = null
+    )
         where TDto : class
         where TResult : class
     {
@@ -158,7 +174,10 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
 
         if (token is not null)
         {
-            requestMessage.Headers.Authorization = new AuthenticationHeaderValue(AuthSchema, token.Value);
+            requestMessage.Headers.Authorization = new AuthenticationHeaderValue(
+                AuthSchema,
+                token.Value
+            );
         }
 
         using var httpResponse = await httpClient.SendAsync(requestMessage, cancellationToken);
@@ -166,16 +185,22 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
 
         if (httpResponse.IsSuccessStatusCode)
         {
-            var dto = string.IsNullOrWhiteSpace(content) ? null : JsonSerializer.Deserialize<TDto>(content);
+            var dto = string.IsNullOrWhiteSpace(content)
+                ? null
+                : JsonSerializer.Deserialize<TDto>(content);
             return new ResponseResult<TResult>(successResult: successFunc(dto));
         }
 
-        var error = string.IsNullOrWhiteSpace(content) ? null : JsonSerializer.Deserialize<DsfinvkErrorResponse>(content);
-        return new ResponseResult<TResult>(errorResult: new ErrorResult(
-            Status: error?.StatusCode ?? (int)httpResponse.StatusCode,
-            Code: null,
-            Error: error?.Error,
-            Message: error?.Message
-        ));
+        var error = string.IsNullOrWhiteSpace(content)
+            ? null
+            : JsonSerializer.Deserialize<DsfinvkErrorResponse>(content);
+        return new ResponseResult<TResult>(
+            errorResult: new ErrorResult(
+                Status: error?.StatusCode ?? (int)httpResponse.StatusCode,
+                Code: error?.Code,
+                Error: error?.Error,
+                Message: error?.Message
+            )
+        );
     }
 }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/DsfinvkApiClient.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/APIClients/DsfinvkApiClient.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using FuncSharp;
 using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK;
 using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.Auth;
 using Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings;
@@ -137,13 +138,14 @@ public class DsfinvkApiClient(HttpClient httpClient, string apiKey, string apiSe
         );
     }
 
-    public async Task<ResponseResult<CashPointClosingResult>> DeleteCashPointClosingAsync(
+    // Delete returns no body; the Nothing result type signals "success, no payload".
+    public async Task<ResponseResult<Nothing>> DeleteCashPointClosingAsync(
         AccessToken token,
         Guid closingId,
         CancellationToken cancellationToken = default
     )
     {
-        return await ProcessRequestAsync<CashPointClosingResponse, CashPointClosingResult>(
+        return await ProcessRequestAsync<CashPointClosingResponse, Nothing>(
             method: HttpMethod.Delete,
             endpoint: $"{CashPointClosingsEndpoint}/{closingId}",
             request: null,

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/CashPointClosingResponse.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/CashPointClosingResponse.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+namespace Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings;
+
+internal sealed class CashPointClosingResponse
+{
+    [JsonPropertyName("closing_id")]
+    public Guid Id { get; init; }
+
+    [JsonPropertyName("client_id")]
+    public Guid ClientId { get; init; }
+
+    [JsonPropertyName("cash_point_closing_export_id")]
+    public long CashPointClosingExportId { get; init; }
+
+    [JsonPropertyName("state")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public CashPointClosingState State { get; init; }
+
+    [JsonPropertyName("error")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Error { get; init; }
+}
+
+internal enum CashPointClosingState
+{
+    PENDING,
+    WORKING,
+    COMPLETED,
+    ERROR,
+    DELETED
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
@@ -29,12 +29,11 @@ internal sealed class CashPointClosingHead
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string BusinessDate { get; init; }
 
+    // Required by the spec (sent even on zero-transaction days; the mapper defaults them to "0").
     [JsonPropertyName("first_transaction_export_id")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string FirstTransactionExportId { get; init; }
 
     [JsonPropertyName("last_transaction_export_id")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string LastTransactionExportId { get; init; }
 }
 
@@ -94,9 +93,33 @@ internal sealed class TransactionReference
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Guid? TxId { get; init; }
 
-    [JsonPropertyName("closing_id")]
+    [JsonPropertyName("cash_point_closing_export_id")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public Guid? ClosingId { get; init; }
+    public long? CashPointClosingExportId { get; init; }
+
+    [JsonPropertyName("cash_register_export_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string CashRegisterExportId { get; init; }
+
+    [JsonPropertyName("transaction_export_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string TransactionExportId { get; init; }
+
+    [JsonPropertyName("external_export_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string ExternalExportId { get; init; }
+
+    [JsonPropertyName("external_other_export_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string ExternalOtherExportId { get; init; }
+
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Name { get; init; }
+
+    [JsonPropertyName("date")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? Date { get; init; }
 }
 
 internal sealed class AllocationGroup
@@ -137,17 +160,21 @@ internal sealed class TransactionLine
     [JsonPropertyName("text")]
     public string ItemText { get; init; }
 
+    [JsonPropertyName("item")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public TransactionLineItem Item { get; init; }
+}
+
+internal sealed class TransactionLineItem
+{
+    [JsonPropertyName("number")]
+    public string Number { get; init; }
+
     [JsonPropertyName("quantity")]
-    public string Quantity { get; init; }
+    public decimal Quantity { get; init; }
 
     [JsonPropertyName("price_per_unit")]
-    public string PricePerUnit { get; init; }
-
-    [JsonPropertyName("gross_amount")]
-    public string GrossAmount { get; init; }
-
-    [JsonPropertyName("net_amount")]
-    public string NetAmount { get; init; }
+    public decimal PricePerUnit { get; init; }
 }
 
 internal sealed class BusinessCase
@@ -182,8 +209,8 @@ internal sealed class PaymentTypeAmount
     [JsonPropertyName("amount")]
     public string Amount { get; init; }
 
+    // Required by the spec.
     [JsonPropertyName("currency_code")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string CurrencyCode { get; init; }
 }
 

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
@@ -1,0 +1,241 @@
+using System.Text.Json.Serialization;
+
+namespace Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings;
+
+internal sealed class InsertCashPointClosingRequest
+{
+    [JsonPropertyName("client_id")]
+    public Guid ClientId { get; init; }
+
+    [JsonPropertyName("cash_point_closing_export_id")]
+    public long CashPointClosingExportId { get; init; }
+
+    [JsonPropertyName("head")]
+    public CashPointClosingHead Head { get; init; }
+
+    [JsonPropertyName("transactions")]
+    public List<CashPointClosingTransaction> Transactions { get; init; }
+
+    [JsonPropertyName("cash_statement")]
+    public CashStatement CashStatement { get; init; }
+}
+
+internal sealed class CashPointClosingHead
+{
+    [JsonPropertyName("export_creation_date")]
+    public long ExportCreationDate { get; init; }
+
+    [JsonPropertyName("business_date")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string BusinessDate { get; init; }
+
+    [JsonPropertyName("first_transaction_export_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string FirstTransactionExportId { get; init; }
+
+    [JsonPropertyName("last_transaction_export_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string LastTransactionExportId { get; init; }
+}
+
+internal sealed class CashPointClosingTransaction
+{
+    [JsonPropertyName("head")]
+    public TransactionHead Head { get; init; }
+
+    [JsonPropertyName("data")]
+    public TransactionData Data { get; init; }
+
+    [JsonPropertyName("security")]
+    public TransactionSecurity Security { get; init; }
+}
+
+internal sealed class TransactionHead
+{
+    [JsonPropertyName("tx_id")]
+    public Guid TxId { get; init; }
+
+    [JsonPropertyName("transaction_export_id")]
+    public string TransactionExportId { get; init; }
+
+    [JsonPropertyName("number")]
+    public long Number { get; init; }
+
+    [JsonPropertyName("timestamp_start")]
+    public long TimestampStart { get; init; }
+
+    [JsonPropertyName("timestamp_end")]
+    public long TimestampEnd { get; init; }
+
+    [JsonPropertyName("storno")]
+    public bool Storno { get; init; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; init; }
+
+    [JsonPropertyName("closing_client_id")]
+    public Guid ClosingClientId { get; init; }
+
+    [JsonPropertyName("references")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<TransactionReference> References { get; init; }
+
+    [JsonPropertyName("allocation_groups")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<AllocationGroup> AllocationGroups { get; init; }
+}
+
+internal sealed class TransactionReference
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; }
+
+    [JsonPropertyName("tx_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Guid? TxId { get; init; }
+
+    [JsonPropertyName("closing_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Guid? ClosingId { get; init; }
+}
+
+internal sealed class AllocationGroup
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; init; }
+}
+
+internal sealed class TransactionData
+{
+    [JsonPropertyName("full_amount_incl_vat")]
+    public string FullAmountInclVat { get; init; }
+
+    [JsonPropertyName("lines")]
+    public List<TransactionLine> Lines { get; init; }
+
+    [JsonPropertyName("amounts_per_vat_id")]
+    public List<AmountPerVat> AmountsPerVatId { get; init; }
+
+    [JsonPropertyName("payment_types")]
+    public List<PaymentTypeAmount> PaymentTypes { get; init; }
+}
+
+internal sealed class TransactionLine
+{
+    [JsonPropertyName("lineitem_export_id")]
+    public string LineItemExportId { get; init; }
+
+    [JsonPropertyName("storno")]
+    public bool Storno { get; init; }
+
+    [JsonPropertyName("business_case")]
+    public BusinessCase BusinessCase { get; init; }
+
+    [JsonPropertyName("text")]
+    public string ItemText { get; init; }
+
+    [JsonPropertyName("quantity")]
+    public string Quantity { get; init; }
+
+    [JsonPropertyName("price_per_unit")]
+    public string PricePerUnit { get; init; }
+
+    [JsonPropertyName("gross_amount")]
+    public string GrossAmount { get; init; }
+
+    [JsonPropertyName("net_amount")]
+    public string NetAmount { get; init; }
+}
+
+internal sealed class BusinessCase
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; }
+
+    [JsonPropertyName("amounts_per_vat_id")]
+    public List<AmountPerVat> AmountsPerVatId { get; init; }
+}
+
+internal sealed class AmountPerVat
+{
+    [JsonPropertyName("vat_definition_export_id")]
+    public int VatDefinitionExportId { get; init; }
+
+    [JsonPropertyName("incl_vat")]
+    public string GrossAmount { get; init; }
+
+    [JsonPropertyName("excl_vat")]
+    public string NetAmount { get; init; }
+
+    [JsonPropertyName("vat")]
+    public string TaxAmount { get; init; }
+}
+
+internal sealed class PaymentTypeAmount
+{
+    [JsonPropertyName("type")]
+    public string PaymentType { get; init; }
+
+    [JsonPropertyName("amount")]
+    public string Amount { get; init; }
+
+    [JsonPropertyName("currency_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string CurrencyCode { get; init; }
+}
+
+internal sealed class TransactionSecurity
+{
+    [JsonPropertyName("tss_tx_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Guid? TssTxId { get; init; }
+
+    [JsonPropertyName("error_message")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string ErrorMessage { get; init; }
+}
+
+internal sealed class CashStatement
+{
+    [JsonPropertyName("business_cases")]
+    public List<BusinessCaseSummary> BusinessCases { get; init; }
+
+    [JsonPropertyName("payment")]
+    public CashStatementPayment Payment { get; init; }
+}
+
+internal sealed class BusinessCaseSummary
+{
+    [JsonPropertyName("type")]
+    public string Type { get; init; }
+
+    [JsonPropertyName("amounts_per_vat_id")]
+    public List<AmountPerVat> AmountsPerVatId { get; init; }
+}
+
+internal sealed class CashStatementPayment
+{
+    [JsonPropertyName("full_amount")]
+    public string FullAmount { get; init; }
+
+    [JsonPropertyName("cash_amount")]
+    public string CashAmount { get; init; }
+
+    [JsonPropertyName("cash_amounts_by_currency")]
+    public List<CashAmountByCurrency> CashAmountsByCurrency { get; init; }
+
+    [JsonPropertyName("payment_types")]
+    public List<PaymentTypeAmount> PaymentTypes { get; init; }
+}
+
+internal sealed class CashAmountByCurrency
+{
+    [JsonPropertyName("currency_code")]
+    public string CurrencyCode { get; init; }
+
+    [JsonPropertyName("amount")]
+    public string Amount { get; init; }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
@@ -82,7 +82,7 @@ internal sealed class TransactionHead
 
     [JsonPropertyName("allocation_groups")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<AllocationGroup> AllocationGroups { get; init; }
+    public List<string> AllocationGroups { get; init; }
 }
 
 internal sealed class TransactionReference
@@ -123,19 +123,10 @@ internal sealed class TransactionReference
     public long? Date { get; init; }
 }
 
-internal sealed class AllocationGroup
-{
-    [JsonPropertyName("id")]
-    public string Id { get; init; }
-
-    [JsonPropertyName("type")]
-    public string Type { get; init; }
-}
-
 internal sealed class TransactionData
 {
     [JsonPropertyName("full_amount_incl_vat")]
-    public string FullAmountInclVat { get; init; }
+    public decimal FullAmountInclVat { get; init; }
 
     [JsonPropertyName("lines")]
     public List<TransactionLine> Lines { get; init; }
@@ -193,13 +184,13 @@ internal sealed class AmountPerVat
     public int VatDefinitionExportId { get; init; }
 
     [JsonPropertyName("incl_vat")]
-    public string GrossAmount { get; init; }
+    public decimal GrossAmount { get; init; }
 
     [JsonPropertyName("excl_vat")]
-    public string NetAmount { get; init; }
+    public decimal NetAmount { get; init; }
 
     [JsonPropertyName("vat")]
-    public string TaxAmount { get; init; }
+    public decimal TaxAmount { get; init; }
 }
 
 internal sealed class PaymentTypeAmount
@@ -208,7 +199,7 @@ internal sealed class PaymentTypeAmount
     public string PaymentType { get; init; }
 
     [JsonPropertyName("amount")]
-    public string Amount { get; init; }
+    public decimal Amount { get; init; }
 
     // Required by the spec.
     [JsonPropertyName("currency_code")]
@@ -247,10 +238,10 @@ internal sealed class BusinessCaseSummary
 internal sealed class CashStatementPayment
 {
     [JsonPropertyName("full_amount")]
-    public string FullAmount { get; init; }
+    public decimal FullAmount { get; init; }
 
     [JsonPropertyName("cash_amount")]
-    public string CashAmount { get; init; }
+    public decimal CashAmount { get; init; }
 
     [JsonPropertyName("cash_amounts_by_currency")]
     public List<CashAmountByCurrency> CashAmountsByCurrency { get; init; }
@@ -265,5 +256,5 @@ internal sealed class CashAmountByCurrency
     public string CurrencyCode { get; init; }
 
     [JsonPropertyName("amount")]
-    public string Amount { get; init; }
+    public decimal Amount { get; init; }
 }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
@@ -29,7 +29,7 @@ internal sealed class CashPointClosingHead
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string BusinessDate { get; init; }
 
-    // Required by the spec (sent even on zero-transaction days; the mapper defaults them to "0").
+    // Required by the spec (the caller sends "0" on zero-transaction days).
     [JsonPropertyName("first_transaction_export_id")]
     public string FirstTransactionExportId { get; init; }
 
@@ -51,8 +51,10 @@ internal sealed class CashPointClosingTransaction
 
 internal sealed class TransactionHead
 {
+    // Optional per spec.
     [JsonPropertyName("tx_id")]
-    public Guid TxId { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Guid? TxId { get; init; }
 
     [JsonPropertyName("transaction_export_id")]
     public string TransactionExportId { get; init; }
@@ -72,6 +74,18 @@ internal sealed class TransactionHead
     [JsonPropertyName("type")]
     public string Type { get; init; }
 
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Name { get; init; }
+
+    [JsonPropertyName("user")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public TransactionUser User { get; init; }
+
+    [JsonPropertyName("buyer")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public TransactionBuyer Buyer { get; init; }
+
     [JsonPropertyName("closing_client_id")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Guid? ClosingClientId { get; init; }
@@ -83,6 +97,55 @@ internal sealed class TransactionHead
     [JsonPropertyName("allocation_groups")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<string> AllocationGroups { get; init; }
+}
+
+internal sealed class TransactionUser
+{
+    [JsonPropertyName("user_export_id")]
+    public string UserExportId { get; init; }
+
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Name { get; init; }
+}
+
+internal sealed class TransactionBuyer
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; }
+
+    [JsonPropertyName("buyer_export_id")]
+    public string BuyerExportId { get; init; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; init; }
+
+    [JsonPropertyName("address")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public BuyerAddress Address { get; init; }
+
+    [JsonPropertyName("vat_id_number")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string VatIdNumber { get; init; }
+}
+
+internal sealed class BuyerAddress
+{
+    [JsonPropertyName("street")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Street { get; init; }
+
+    [JsonPropertyName("postal_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string PostalCode { get; init; }
+
+    [JsonPropertyName("city")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string City { get; init; }
+
+    [JsonPropertyName("country_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string CountryCode { get; init; }
 }
 
 internal sealed class TransactionReference
@@ -129,13 +192,20 @@ internal sealed class TransactionData
     public decimal FullAmountInclVat { get; init; }
 
     [JsonPropertyName("lines")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<TransactionLine> Lines { get; init; }
 
     [JsonPropertyName("amounts_per_vat_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<AmountPerVat> AmountsPerVatId { get; init; }
 
     [JsonPropertyName("payment_types")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<PaymentTypeAmount> PaymentTypes { get; init; }
+
+    [JsonPropertyName("notes")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Notes { get; init; }
 }
 
 internal sealed class TransactionLine
@@ -149,12 +219,28 @@ internal sealed class TransactionLine
     [JsonPropertyName("business_case")]
     public BusinessCase BusinessCase { get; init; }
 
+    [JsonPropertyName("in_house")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? InHouse { get; init; }
+
+    [JsonPropertyName("references")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<TransactionReference> References { get; init; }
+
+    [JsonPropertyName("voucher_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string VoucherId { get; init; }
+
     [JsonPropertyName("text")]
     public string ItemText { get; init; }
 
     [JsonPropertyName("item")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public TransactionLineItem Item { get; init; }
+
+    [JsonPropertyName("source_cash_register")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Guid? SourceCashRegister { get; init; }
 }
 
 internal sealed class TransactionLineItem
@@ -162,17 +248,115 @@ internal sealed class TransactionLineItem
     [JsonPropertyName("number")]
     public string Number { get; init; }
 
+    [JsonPropertyName("gtin")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Gtin { get; init; }
+
     [JsonPropertyName("quantity")]
     public decimal Quantity { get; init; }
 
+    [JsonPropertyName("quantity_factor")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public decimal? QuantityFactor { get; init; }
+
+    [JsonPropertyName("quantity_measure")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string QuantityMeasure { get; init; }
+
+    [JsonPropertyName("group_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string GroupId { get; init; }
+
+    [JsonPropertyName("group_name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string GroupName { get; init; }
+
     [JsonPropertyName("price_per_unit")]
     public decimal PricePerUnit { get; init; }
+
+    [JsonPropertyName("base_amounts_per_vat_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<VatAmountBreakdown> BaseAmountsPerVatId { get; init; }
+
+    [JsonPropertyName("discounts_per_vat_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<VatAmountBreakdown> DiscountsPerVatId { get; init; }
+
+    [JsonPropertyName("extra_amounts_per_vat_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<VatAmountBreakdown> ExtraAmountsPerVatId { get; init; }
+
+    [JsonPropertyName("sub_items")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<TransactionSubItem> SubItems { get; init; }
+}
+
+internal sealed class VatAmountBreakdown
+{
+    [JsonPropertyName("vat_definition_export_id")]
+    public long VatDefinitionExportId { get; init; }
+
+    [JsonPropertyName("incl_vat")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public decimal? InclVat { get; init; }
+
+    [JsonPropertyName("excl_vat")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public decimal? ExclVat { get; init; }
+
+    [JsonPropertyName("vat")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public decimal? Vat { get; init; }
+}
+
+internal sealed class TransactionSubItem
+{
+    [JsonPropertyName("number")]
+    public string Number { get; init; }
+
+    [JsonPropertyName("gtin")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Gtin { get; init; }
+
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Name { get; init; }
+
+    [JsonPropertyName("quantity")]
+    public decimal Quantity { get; init; }
+
+    [JsonPropertyName("quantity_factor")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public decimal? QuantityFactor { get; init; }
+
+    [JsonPropertyName("quantity_measure")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string QuantityMeasure { get; init; }
+
+    [JsonPropertyName("group_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string GroupId { get; init; }
+
+    [JsonPropertyName("group_name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string GroupName { get; init; }
+
+    [JsonPropertyName("amount_per_vat_id")]
+    public VatAmountBreakdown AmountPerVatId { get; init; }
 }
 
 internal sealed class BusinessCase
 {
     [JsonPropertyName("type")]
     public string Type { get; init; }
+
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Name { get; init; }
+
+    [JsonPropertyName("purchaser_agency_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Guid? PurchaserAgencyId { get; init; }
 
     [JsonPropertyName("amounts_per_vat_id")]
     public List<AmountPerVat> AmountsPerVatId { get; init; }
@@ -181,7 +365,7 @@ internal sealed class BusinessCase
 internal sealed class AmountPerVat
 {
     [JsonPropertyName("vat_definition_export_id")]
-    public int VatDefinitionExportId { get; init; }
+    public long VatDefinitionExportId { get; init; }
 
     [JsonPropertyName("incl_vat")]
     public decimal GrossAmount { get; init; }
@@ -198,8 +382,16 @@ internal sealed class PaymentTypeAmount
     [JsonPropertyName("type")]
     public string PaymentType { get; init; }
 
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string Name { get; init; }
+
     [JsonPropertyName("amount")]
     public decimal Amount { get; init; }
+
+    [JsonPropertyName("foreign_amount")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public decimal? ForeignAmount { get; init; }
 
     // Required by the spec.
     [JsonPropertyName("currency_code")]

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
@@ -73,7 +73,8 @@ internal sealed class TransactionHead
     public string Type { get; init; }
 
     [JsonPropertyName("closing_client_id")]
-    public Guid ClosingClientId { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Guid? ClosingClientId { get; init; }
 
     [JsonPropertyName("references")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/DsfinvkErrorResponse.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/DsfinvkErrorResponse.cs
@@ -10,6 +10,9 @@ internal sealed class DsfinvkErrorResponse
     [JsonPropertyName("error")]
     public string Error { get; init; }
 
+    [JsonPropertyName("code")]
+    public string Code { get; init; }
+
     [JsonPropertyName("message")]
     public string Message { get; init; }
 }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
@@ -1,0 +1,217 @@
+using System.Globalization;
+using Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+using AmountPerVatDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.AmountPerVat;
+using AllocationGroupDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.AllocationGroup;
+using BusinessCaseDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.BusinessCase;
+using BusinessCaseSummaryDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.BusinessCaseSummary;
+using CashAmountByCurrencyDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashAmountByCurrency;
+using CashPointClosingHeadDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashPointClosingHead;
+using CashPointClosingStateDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashPointClosingState;
+using CashPointClosingTransactionDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashPointClosingTransaction;
+using CashStatementDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashStatement;
+using CashStatementPaymentDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashStatementPayment;
+using InsertCashPointClosingRequestDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.InsertCashPointClosingRequest;
+using PaymentTypeAmountDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.PaymentTypeAmount;
+using TransactionDataDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionData;
+using TransactionHeadDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionHead;
+using TransactionLineDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionLine;
+using TransactionReferenceDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionReference;
+using TransactionSecurityDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionSecurity;
+using CashPointClosingResponseDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashPointClosingResponse;
+
+namespace Mews.Fiscalizations.Fiskaly.Mappers.DSFinVK.CashPointClosings;
+
+internal static class CashPointClosingMapper
+{
+    public static InsertCashPointClosingRequestDto MapInsertRequest(CashPointClosing closing)
+    {
+        var transactions = closing.Transactions.ToList();
+
+        return new InsertCashPointClosingRequestDto
+        {
+            ClientId = closing.ClientId,
+            CashPointClosingExportId = closing.CashPointClosingExportId,
+            Head = new CashPointClosingHeadDto
+            {
+                ExportCreationDate = closing.ExportCreationDate.ToUnixTimeSeconds(),
+                BusinessDate = closing.BusinessDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+                FirstTransactionExportId = transactions.FirstOrDefault()?.TransactionExportId,
+                LastTransactionExportId = transactions.LastOrDefault()?.TransactionExportId
+            },
+            Transactions = transactions.Select(MapTransaction).ToList(),
+            CashStatement = MapCashStatement(closing.CashStatement)
+        };
+    }
+
+    public static CashPointClosingResult MapResponse(this CashPointClosingResponseDto response)
+    {
+        return new CashPointClosingResult(
+            Id: response.Id,
+            ClientId: response.ClientId,
+            CashPointClosingExportId: response.CashPointClosingExportId,
+            State: MapState(response.State),
+            Error: response.Error
+        );
+    }
+
+    private static CashPointClosingTransactionDto MapTransaction(CashPointClosingTransaction tx)
+    {
+        return new CashPointClosingTransactionDto
+        {
+            Head = new TransactionHeadDto
+            {
+                TxId = tx.TxId,
+                TransactionExportId = tx.TransactionExportId,
+                Number = tx.Number,
+                TimestampStart = tx.TimestampStart.ToUnixTimeSeconds(),
+                TimestampEnd = tx.TimestampEnd.ToUnixTimeSeconds(),
+                Storno = tx.Storno,
+                Type = MapProcessType(tx.ProcessType),
+                ClosingClientId = tx.ClosingClientId,
+                References = tx.References?.Select(MapReference).ToList()
+            },
+            Data = new TransactionDataDto
+            {
+                FullAmountInclVat = tx.FullAmountInclVat.ToString("F2", CultureInfo.InvariantCulture),
+                Lines = tx.Lines.Select(MapLine).ToList(),
+                AmountsPerVatId = tx.AmountsPerVat.Select(MapAmountPerVat).ToList(),
+                PaymentTypes = tx.PaymentTypes.Select(MapPaymentType).ToList()
+            },
+            Security = new TransactionSecurityDto
+            {
+                TssTxId = tx.Security.TssTxId,
+                ErrorMessage = tx.Security.ErrorMessage
+            }
+        };
+    }
+
+    private static TransactionReferenceDto MapReference(TransactionReference reference)
+    {
+        return new TransactionReferenceDto
+        {
+            Type = "InterneTransaktion",
+            TxId = reference.TxId,
+            ClosingId = reference.ClosingId
+        };
+    }
+
+    private static TransactionLineDto MapLine(TransactionLine line)
+    {
+        return new TransactionLineDto
+        {
+            LineItemExportId = line.LineItemExportId,
+            Storno = line.Storno,
+            BusinessCase = new BusinessCaseDto
+            {
+                Type = MapBusinessTransactionType(line.BusinessTransactionType),
+                AmountsPerVatId = line.BusinessCaseAmountsPerVat.Select(MapAmountPerVat).ToList()
+            },
+            ItemText = line.ItemText,
+            Quantity = line.Quantity.ToString("F2", CultureInfo.InvariantCulture),
+            PricePerUnit = line.PricePerUnit.ToString("F2", CultureInfo.InvariantCulture),
+            GrossAmount = line.GrossAmount.ToString("F2", CultureInfo.InvariantCulture),
+            NetAmount = line.NetAmount.ToString("F2", CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static AmountPerVatDto MapAmountPerVat(AmountPerVat amount)
+    {
+        return new AmountPerVatDto
+        {
+            VatDefinitionExportId = amount.VatDefinitionExportId,
+            GrossAmount = amount.GrossAmount.ToString("F2", CultureInfo.InvariantCulture),
+            NetAmount = amount.NetAmount.ToString("F2", CultureInfo.InvariantCulture),
+            TaxAmount = amount.TaxAmount.ToString("F2", CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static PaymentTypeAmountDto MapPaymentType(PaymentTypeAmount payment)
+    {
+        return new PaymentTypeAmountDto
+        {
+            PaymentType = payment.PaymentType,
+            Amount = payment.Amount.ToString("F2", CultureInfo.InvariantCulture),
+            CurrencyCode = payment.CurrencyCode
+        };
+    }
+
+    private static CashStatementDto MapCashStatement(CashStatement cashStatement)
+    {
+        return new CashStatementDto
+        {
+            BusinessCases = cashStatement.BusinessCases.Select(bc => new BusinessCaseSummaryDto
+            {
+                Type = MapBusinessTransactionType(bc.Type),
+                AmountsPerVatId = bc.AmountsPerVat.Select(MapAmountPerVat).ToList()
+            }).ToList(),
+            Payment = new CashStatementPaymentDto
+            {
+                FullAmount = cashStatement.Payment.FullAmount.ToString("F2", CultureInfo.InvariantCulture),
+                CashAmount = cashStatement.Payment.CashAmount.ToString("F2", CultureInfo.InvariantCulture),
+                CashAmountsByCurrency = cashStatement.Payment.CashAmountsByCurrency
+                    .Select(c => new CashAmountByCurrencyDto
+                    {
+                        CurrencyCode = c.CurrencyCode,
+                        Amount = c.Amount.ToString("F2", CultureInfo.InvariantCulture)
+                    }).ToList(),
+                PaymentTypes = cashStatement.Payment.PaymentTypes.Select(MapPaymentType).ToList()
+            }
+        };
+    }
+
+    private static string MapProcessType(ProcessType type)
+    {
+        return type switch
+        {
+            ProcessType.Receipt => "Beleg",
+            ProcessType.Transfer => "AVTransfer",
+            ProcessType.Order => "AVBestellung",
+            ProcessType.Cancellation => "AVBelegstorno",
+            ProcessType.Training => "AVTraining",
+            ProcessType.BenefitInKind => "AVSachbezug",
+            ProcessType.Invoice => "AVRechnung",
+            ProcessType.Other => "AVSonstige",
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+        };
+    }
+
+    private static string MapBusinessTransactionType(BusinessTransactionType type)
+    {
+        return type switch
+        {
+            BusinessTransactionType.Umsatz => "Umsatz",
+            BusinessTransactionType.Pfand => "Pfand",
+            BusinessTransactionType.PfandRueckzahlung => "PfandRueckzahlung",
+            BusinessTransactionType.Rabatt => "Rabatt",
+            BusinessTransactionType.Aufschlag => "Aufschlag",
+            BusinessTransactionType.MehrzweckgutscheinKauf => "MehrzweckgutscheinKauf",
+            BusinessTransactionType.MehrzweckgutscheinEinloesung => "MehrzweckgutscheinEinloesung",
+            BusinessTransactionType.EinzweckgutscheinKauf => "EinzweckgutscheinKauf",
+            BusinessTransactionType.EinzweckgutscheinEinloesung => "EinzweckgutscheinEinloesung",
+            BusinessTransactionType.Anzahlungseinstellung => "Anzahlungseinstellung",
+            BusinessTransactionType.Anzahlungsaufloesung => "Anzahlungsaufloesung",
+            BusinessTransactionType.Forderungsentstehung => "Forderungsentstehung",
+            BusinessTransactionType.Forderungsaufloesung => "Forderungsaufloesung",
+            BusinessTransactionType.Geldtransit => "Geldtransit",
+            BusinessTransactionType.Einzahlung => "Einzahlung",
+            BusinessTransactionType.Auszahlung => "Auszahlung",
+            BusinessTransactionType.TrinkgeldAG => "TrinkgeldAG",
+            BusinessTransactionType.TrinkgeldAN => "TrinkgeldAN",
+            BusinessTransactionType.DifferenzSollIst => "DifferenzSollIst",
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+        };
+    }
+
+    private static CashPointClosingState MapState(CashPointClosingStateDto state)
+    {
+        return state switch
+        {
+            CashPointClosingStateDto.PENDING => CashPointClosingState.Pending,
+            CashPointClosingStateDto.WORKING => CashPointClosingState.Working,
+            CashPointClosingStateDto.COMPLETED => CashPointClosingState.Completed,
+            CashPointClosingStateDto.ERROR => CashPointClosingState.Error,
+            CashPointClosingStateDto.DELETED => CashPointClosingState.Deleted,
+            _ => throw new ArgumentOutOfRangeException(nameof(state), state, null)
+        };
+    }
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
@@ -265,11 +265,26 @@ internal static class CashPointClosingMapper
     {
         return new PaymentTypeAmountDto
         {
-            PaymentType = payment.PaymentType,
+            PaymentType = MapPaymentTypeName(payment.PaymentType),
             Name = payment.Name,
             Amount = payment.Amount,
             ForeignAmount = payment.ForeignAmount,
             CurrencyCode = payment.CurrencyCode,
+        };
+    }
+
+    private static string MapPaymentTypeName(PaymentType type)
+    {
+        return type switch
+        {
+            PaymentType.Cash => "Bar",
+            PaymentType.NonCash => "Unbar",
+            PaymentType.DebitCard => "ECKarte",
+            PaymentType.CreditCard => "Kreditkarte",
+            PaymentType.ElectronicPaymentServiceProvider => "ElZahlungsdienstleister",
+            PaymentType.VoucherCard => "Guthabenkarte",
+            PaymentType.None => "Keine",
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
         };
     }
 

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
@@ -3,21 +3,26 @@ using Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
 using AmountPerVatDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.AmountPerVat;
 using BusinessCaseDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.BusinessCase;
 using BusinessCaseSummaryDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.BusinessCaseSummary;
+using BuyerAddressDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.BuyerAddress;
 using CashAmountByCurrencyDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashAmountByCurrency;
 using CashPointClosingHeadDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashPointClosingHead;
+using CashPointClosingResponseDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashPointClosingResponse;
 using CashPointClosingStateDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashPointClosingState;
 using CashPointClosingTransactionDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashPointClosingTransaction;
 using CashStatementDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashStatement;
 using CashStatementPaymentDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashStatementPayment;
 using InsertCashPointClosingRequestDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.InsertCashPointClosingRequest;
 using PaymentTypeAmountDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.PaymentTypeAmount;
+using TransactionBuyerDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionBuyer;
 using TransactionDataDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionData;
 using TransactionHeadDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionHead;
 using TransactionLineDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionLine;
 using TransactionLineItemDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionLineItem;
 using TransactionReferenceDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionReference;
 using TransactionSecurityDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionSecurity;
-using CashPointClosingResponseDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashPointClosingResponse;
+using TransactionSubItemDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionSubItem;
+using TransactionUserDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionUser;
+using VatAmountBreakdownDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.VatAmountBreakdown;
 
 namespace Mews.Fiscalizations.Fiskaly.Mappers.DSFinVK.CashPointClosings;
 
@@ -34,12 +39,15 @@ internal static class CashPointClosingMapper
             Head = new CashPointClosingHeadDto
             {
                 ExportCreationDate = closing.ExportCreationDate.ToUnixTimeSeconds(),
-                BusinessDate = closing.BusinessDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-                FirstTransactionExportId = transactions.FirstOrDefault()?.TransactionExportId ?? "0",
-                LastTransactionExportId = transactions.LastOrDefault()?.TransactionExportId ?? "0"
+                BusinessDate = closing.BusinessDate.ToString(
+                    "yyyy-MM-dd",
+                    CultureInfo.InvariantCulture
+                ),
+                FirstTransactionExportId = closing.FirstTransactionExportId,
+                LastTransactionExportId = closing.LastTransactionExportId,
             },
             Transactions = transactions.Select(MapTransaction).ToList(),
-            CashStatement = MapCashStatement(closing.CashStatement)
+            CashStatement = MapCashStatement(closing.CashStatement),
         };
     }
 
@@ -67,22 +75,26 @@ internal static class CashPointClosingMapper
                 TimestampEnd = tx.TimestampEnd.ToUnixTimeSeconds(),
                 Storno = tx.Storno,
                 Type = MapProcessType(tx.ProcessType),
+                Name = tx.Name,
+                User = MapUser(tx.User),
+                Buyer = MapBuyer(tx.Buyer),
                 ClosingClientId = tx.ClosingClientId,
                 References = tx.References?.Select(MapReference).ToList(),
-                AllocationGroups = tx.AllocationGroups?.ToList()
+                AllocationGroups = tx.AllocationGroups?.ToList(),
             },
             Data = new TransactionDataDto
             {
                 FullAmountInclVat = tx.FullAmountInclVat,
                 Lines = tx.Lines.Select(MapLine).ToList(),
                 AmountsPerVatId = tx.AmountsPerVat.Select(MapAmountPerVat).ToList(),
-                PaymentTypes = tx.PaymentTypes.Select(MapPaymentType).ToList()
+                PaymentTypes = tx.PaymentTypes.Select(MapPaymentType).ToList(),
+                Notes = tx.Notes,
             },
             Security = new TransactionSecurityDto
             {
                 TssTxId = tx.Security.TssTxId,
-                ErrorMessage = tx.Security.ErrorMessage
-            }
+                ErrorMessage = tx.Security.ErrorMessage,
+            },
         };
     }
 
@@ -98,7 +110,7 @@ internal static class CashPointClosingMapper
             ExternalExportId = reference.ExternalExportId,
             ExternalOtherExportId = reference.ExternalOtherExportId,
             Name = reference.Name,
-            Date = reference.Date?.ToUnixTimeSeconds()
+            Date = reference.Date?.ToUnixTimeSeconds(),
         };
     }
 
@@ -111,7 +123,57 @@ internal static class CashPointClosingMapper
             ReferenceType.ExternalBill => "ExterneRechnung",
             ReferenceType.ExternalDeliveryNote => "ExternerLieferschein",
             ReferenceType.ExternalOther => "ExterneSonstige",
-            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
+        };
+    }
+
+    private static TransactionUserDto MapUser(TransactionUser user)
+    {
+        if (user == null)
+        {
+            return null;
+        }
+        return new TransactionUserDto { UserExportId = user.UserExportId, Name = user.Name };
+    }
+
+    private static TransactionBuyerDto MapBuyer(TransactionBuyer buyer)
+    {
+        if (buyer == null)
+        {
+            return null;
+        }
+        return new TransactionBuyerDto
+        {
+            Name = buyer.Name,
+            BuyerExportId = buyer.BuyerExportId,
+            Type = MapBuyerType(buyer.Type),
+            VatIdNumber = buyer.VatIdNumber,
+            Address = MapAddress(buyer.Address),
+        };
+    }
+
+    private static string MapBuyerType(BuyerType type)
+    {
+        return type switch
+        {
+            BuyerType.Customer => "Kunde",
+            BuyerType.Employee => "Mitarbeiter",
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
+        };
+    }
+
+    private static BuyerAddressDto MapAddress(BuyerAddress address)
+    {
+        if (address == null)
+        {
+            return null;
+        }
+        return new BuyerAddressDto
+        {
+            Street = address.Street,
+            PostalCode = address.PostalCode,
+            City = address.City,
+            CountryCode = address.CountryCode,
         };
     }
 
@@ -124,15 +186,39 @@ internal static class CashPointClosingMapper
             BusinessCase = new BusinessCaseDto
             {
                 Type = MapBusinessTransactionType(line.BusinessTransactionType),
-                AmountsPerVatId = line.BusinessCaseAmountsPerVat.Select(MapAmountPerVat).ToList()
+                Name = line.BusinessCaseName,
+                PurchaserAgencyId = line.PurchaserAgencyId,
+                AmountsPerVatId = line.BusinessCaseAmountsPerVat.Select(MapAmountPerVat).ToList(),
             },
+            InHouse = line.InHouse,
+            References = line.References?.Select(MapReference).ToList(),
+            VoucherId = line.VoucherId,
             ItemText = line.ItemText,
-            Item = line.Item == null ? null : new TransactionLineItemDto
-            {
-                Number = line.Item.Number,
-                Quantity = line.Item.Quantity,
-                PricePerUnit = line.Item.PricePerUnit
-            }
+            Item =
+                line.Item == null
+                    ? null
+                    : new TransactionLineItemDto
+                    {
+                        Number = line.Item.Number,
+                        Gtin = line.Item.Gtin,
+                        Quantity = line.Item.Quantity,
+                        QuantityFactor = line.Item.QuantityFactor,
+                        QuantityMeasure = line.Item.QuantityMeasure,
+                        GroupId = line.Item.GroupId,
+                        GroupName = line.Item.GroupName,
+                        PricePerUnit = line.Item.PricePerUnit,
+                        BaseAmountsPerVatId = line
+                            .Item.BaseAmountsPerVat?.Select(MapVatBreakdown)
+                            .ToList(),
+                        DiscountsPerVatId = line
+                            .Item.DiscountsPerVat?.Select(MapVatBreakdown)
+                            .ToList(),
+                        ExtraAmountsPerVatId = line
+                            .Item.ExtraAmountsPerVat?.Select(MapVatBreakdown)
+                            .ToList(),
+                        SubItems = line.Item.SubItems?.Select(MapSubItem).ToList(),
+                    },
+            SourceCashRegister = line.SourceCashRegister,
         };
     }
 
@@ -143,7 +229,35 @@ internal static class CashPointClosingMapper
             VatDefinitionExportId = amount.VatDefinitionExportId,
             GrossAmount = amount.GrossAmount,
             NetAmount = amount.NetAmount,
-            TaxAmount = amount.TaxAmount
+            TaxAmount = amount.TaxAmount,
+        };
+    }
+
+    private static VatAmountBreakdownDto MapVatBreakdown(VatAmountBreakdown amount)
+    {
+        return new VatAmountBreakdownDto
+        {
+            VatDefinitionExportId = amount.VatDefinitionExportId,
+            InclVat = amount.InclVat,
+            ExclVat = amount.ExclVat,
+            Vat = amount.Vat,
+        };
+    }
+
+    private static TransactionSubItemDto MapSubItem(TransactionSubItem subItem)
+    {
+        return new TransactionSubItemDto
+        {
+            Number = subItem.Number,
+            Gtin = subItem.Gtin,
+            Name = subItem.Name,
+            Quantity = subItem.Quantity,
+            QuantityFactor = subItem.QuantityFactor,
+            QuantityMeasure = subItem.QuantityMeasure,
+            GroupId = subItem.GroupId,
+            GroupName = subItem.GroupName,
+            AmountPerVatId =
+                subItem.AmountPerVat == null ? null : MapVatBreakdown(subItem.AmountPerVat),
         };
     }
 
@@ -152,8 +266,10 @@ internal static class CashPointClosingMapper
         return new PaymentTypeAmountDto
         {
             PaymentType = payment.PaymentType,
+            Name = payment.Name,
             Amount = payment.Amount,
-            CurrencyCode = payment.CurrencyCode
+            ForeignAmount = payment.ForeignAmount,
+            CurrencyCode = payment.CurrencyCode,
         };
     }
 
@@ -161,23 +277,26 @@ internal static class CashPointClosingMapper
     {
         return new CashStatementDto
         {
-            BusinessCases = cashStatement.BusinessCases.Select(bc => new BusinessCaseSummaryDto
-            {
-                Type = MapBusinessTransactionType(bc.Type),
-                AmountsPerVatId = bc.AmountsPerVat.Select(MapAmountPerVat).ToList()
-            }).ToList(),
+            BusinessCases = cashStatement
+                .BusinessCases.Select(bc => new BusinessCaseSummaryDto
+                {
+                    Type = MapBusinessTransactionType(bc.Type),
+                    AmountsPerVatId = bc.AmountsPerVat.Select(MapAmountPerVat).ToList(),
+                })
+                .ToList(),
             Payment = new CashStatementPaymentDto
             {
                 FullAmount = cashStatement.Payment.FullAmount,
                 CashAmount = cashStatement.Payment.CashAmount,
-                CashAmountsByCurrency = cashStatement.Payment.CashAmountsByCurrency
-                    .Select(c => new CashAmountByCurrencyDto
+                CashAmountsByCurrency = cashStatement
+                    .Payment.CashAmountsByCurrency.Select(c => new CashAmountByCurrencyDto
                     {
                         CurrencyCode = c.CurrencyCode,
-                        Amount = c.Amount
-                    }).ToList(),
-                PaymentTypes = cashStatement.Payment.PaymentTypes.Select(MapPaymentType).ToList()
-            }
+                        Amount = c.Amount,
+                    })
+                    .ToList(),
+                PaymentTypes = cashStatement.Payment.PaymentTypes.Select(MapPaymentType).ToList(),
+            },
         };
     }
 
@@ -193,7 +312,7 @@ internal static class CashPointClosingMapper
             ProcessType.BenefitInKind => "AVSachbezug",
             ProcessType.Invoice => "AVRechnung",
             ProcessType.Other => "AVSonstige",
-            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
         };
     }
 
@@ -201,6 +320,7 @@ internal static class CashPointClosingMapper
     {
         return type switch
         {
+            BusinessTransactionType.Anfangsbestand => "Anfangsbestand",
             BusinessTransactionType.Umsatz => "Umsatz",
             BusinessTransactionType.Pfand => "Pfand",
             BusinessTransactionType.PfandRueckzahlung => "PfandRueckzahlung",
@@ -214,13 +334,18 @@ internal static class CashPointClosingMapper
             BusinessTransactionType.Anzahlungsaufloesung => "Anzahlungsaufloesung",
             BusinessTransactionType.Forderungsentstehung => "Forderungsentstehung",
             BusinessTransactionType.Forderungsaufloesung => "Forderungsaufloesung",
+            BusinessTransactionType.Privateinlage => "Privateinlage",
+            BusinessTransactionType.Privatentnahme => "Privatentnahme",
             BusinessTransactionType.Geldtransit => "Geldtransit",
             BusinessTransactionType.Einzahlung => "Einzahlung",
             BusinessTransactionType.Auszahlung => "Auszahlung",
+            BusinessTransactionType.Lohnzahlung => "Lohnzahlung",
             BusinessTransactionType.TrinkgeldAG => "TrinkgeldAG",
             BusinessTransactionType.TrinkgeldAN => "TrinkgeldAN",
+            BusinessTransactionType.ZuschussEcht => "ZuschussEcht",
+            BusinessTransactionType.ZuschussUnecht => "ZuschussUnecht",
             BusinessTransactionType.DifferenzSollIst => "DifferenzSollIst",
-            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null),
         };
     }
 
@@ -233,7 +358,7 @@ internal static class CashPointClosingMapper
             CashPointClosingStateDto.COMPLETED => CashPointClosingState.Completed,
             CashPointClosingStateDto.ERROR => CashPointClosingState.Error,
             CashPointClosingStateDto.DELETED => CashPointClosingState.Deleted,
-            _ => throw new ArgumentOutOfRangeException(nameof(state), state, null)
+            _ => throw new ArgumentOutOfRangeException(nameof(state), state, null),
         };
     }
 }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
 using AmountPerVatDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.AmountPerVat;
-using AllocationGroupDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.AllocationGroup;
 using BusinessCaseDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.BusinessCase;
 using BusinessCaseSummaryDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.BusinessCaseSummary;
 using CashAmountByCurrencyDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashAmountByCurrency;
@@ -69,11 +68,12 @@ internal static class CashPointClosingMapper
                 Storno = tx.Storno,
                 Type = MapProcessType(tx.ProcessType),
                 ClosingClientId = tx.ClosingClientId,
-                References = tx.References?.Select(MapReference).ToList()
+                References = tx.References?.Select(MapReference).ToList(),
+                AllocationGroups = tx.AllocationGroups?.ToList()
             },
             Data = new TransactionDataDto
             {
-                FullAmountInclVat = tx.FullAmountInclVat.ToString("F2", CultureInfo.InvariantCulture),
+                FullAmountInclVat = tx.FullAmountInclVat,
                 Lines = tx.Lines.Select(MapLine).ToList(),
                 AmountsPerVatId = tx.AmountsPerVat.Select(MapAmountPerVat).ToList(),
                 PaymentTypes = tx.PaymentTypes.Select(MapPaymentType).ToList()
@@ -141,9 +141,9 @@ internal static class CashPointClosingMapper
         return new AmountPerVatDto
         {
             VatDefinitionExportId = amount.VatDefinitionExportId,
-            GrossAmount = amount.GrossAmount.ToString("F2", CultureInfo.InvariantCulture),
-            NetAmount = amount.NetAmount.ToString("F2", CultureInfo.InvariantCulture),
-            TaxAmount = amount.TaxAmount.ToString("F2", CultureInfo.InvariantCulture)
+            GrossAmount = amount.GrossAmount,
+            NetAmount = amount.NetAmount,
+            TaxAmount = amount.TaxAmount
         };
     }
 
@@ -152,7 +152,7 @@ internal static class CashPointClosingMapper
         return new PaymentTypeAmountDto
         {
             PaymentType = payment.PaymentType,
-            Amount = payment.Amount.ToString("F2", CultureInfo.InvariantCulture),
+            Amount = payment.Amount,
             CurrencyCode = payment.CurrencyCode
         };
     }
@@ -168,13 +168,13 @@ internal static class CashPointClosingMapper
             }).ToList(),
             Payment = new CashStatementPaymentDto
             {
-                FullAmount = cashStatement.Payment.FullAmount.ToString("F2", CultureInfo.InvariantCulture),
-                CashAmount = cashStatement.Payment.CashAmount.ToString("F2", CultureInfo.InvariantCulture),
+                FullAmount = cashStatement.Payment.FullAmount,
+                CashAmount = cashStatement.Payment.CashAmount,
                 CashAmountsByCurrency = cashStatement.Payment.CashAmountsByCurrency
                     .Select(c => new CashAmountByCurrencyDto
                     {
                         CurrencyCode = c.CurrencyCode,
-                        Amount = c.Amount.ToString("F2", CultureInfo.InvariantCulture)
+                        Amount = c.Amount
                     }).ToList(),
                 PaymentTypes = cashStatement.Payment.PaymentTypes.Select(MapPaymentType).ToList()
             }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
@@ -15,6 +15,7 @@ using PaymentTypeAmountDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointC
 using TransactionDataDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionData;
 using TransactionHeadDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionHead;
 using TransactionLineDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionLine;
+using TransactionLineItemDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionLineItem;
 using TransactionReferenceDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionReference;
 using TransactionSecurityDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.TransactionSecurity;
 using CashPointClosingResponseDto = Mews.Fiscalizations.Fiskaly.DTOs.DSFinVK.CashPointClosings.CashPointClosingResponse;
@@ -35,8 +36,8 @@ internal static class CashPointClosingMapper
             {
                 ExportCreationDate = closing.ExportCreationDate.ToUnixTimeSeconds(),
                 BusinessDate = closing.BusinessDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
-                FirstTransactionExportId = transactions.FirstOrDefault()?.TransactionExportId,
-                LastTransactionExportId = transactions.LastOrDefault()?.TransactionExportId
+                FirstTransactionExportId = transactions.FirstOrDefault()?.TransactionExportId ?? "0",
+                LastTransactionExportId = transactions.LastOrDefault()?.TransactionExportId ?? "0"
             },
             Transactions = transactions.Select(MapTransaction).ToList(),
             CashStatement = MapCashStatement(closing.CashStatement)
@@ -89,9 +90,28 @@ internal static class CashPointClosingMapper
     {
         return new TransactionReferenceDto
         {
-            Type = "InterneTransaktion",
+            Type = MapReferenceType(reference.Type),
             TxId = reference.TxId,
-            ClosingId = reference.ClosingId
+            CashPointClosingExportId = reference.CashPointClosingExportId,
+            CashRegisterExportId = reference.CashRegisterExportId,
+            TransactionExportId = reference.TransactionExportId,
+            ExternalExportId = reference.ExternalExportId,
+            ExternalOtherExportId = reference.ExternalOtherExportId,
+            Name = reference.Name,
+            Date = reference.Date?.ToUnixTimeSeconds()
+        };
+    }
+
+    private static string MapReferenceType(ReferenceType type)
+    {
+        return type switch
+        {
+            ReferenceType.InternalTransaction => "InterneTransaktion",
+            ReferenceType.Transaction => "Transaktion",
+            ReferenceType.ExternalBill => "ExterneRechnung",
+            ReferenceType.ExternalDeliveryNote => "ExternerLieferschein",
+            ReferenceType.ExternalOther => "ExterneSonstige",
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
         };
     }
 
@@ -107,10 +127,12 @@ internal static class CashPointClosingMapper
                 AmountsPerVatId = line.BusinessCaseAmountsPerVat.Select(MapAmountPerVat).ToList()
             },
             ItemText = line.ItemText,
-            Quantity = line.Quantity.ToString("F2", CultureInfo.InvariantCulture),
-            PricePerUnit = line.PricePerUnit.ToString("F2", CultureInfo.InvariantCulture),
-            GrossAmount = line.GrossAmount.ToString("F2", CultureInfo.InvariantCulture),
-            NetAmount = line.NetAmount.ToString("F2", CultureInfo.InvariantCulture)
+            Item = new TransactionLineItemDto
+            {
+                Number = line.LineItemExportId,
+                Quantity = line.Quantity,
+                PricePerUnit = line.PricePerUnit
+            }
         };
     }
 

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
@@ -127,11 +127,11 @@ internal static class CashPointClosingMapper
                 AmountsPerVatId = line.BusinessCaseAmountsPerVat.Select(MapAmountPerVat).ToList()
             },
             ItemText = line.ItemText,
-            Item = new TransactionLineItemDto
+            Item = line.Item == null ? null : new TransactionLineItemDto
             {
-                Number = line.LineItemExportId,
-                Quantity = line.Quantity,
-                PricePerUnit = line.PricePerUnit
+                Number = line.Item.Number,
+                Quantity = line.Item.Quantity,
+                PricePerUnit = line.Item.PricePerUnit
             }
         };
     }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mews.Fiscalizations.Fiskaly.csproj
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mews.Fiscalizations.Fiskaly.csproj
@@ -9,7 +9,7 @@
         <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
         <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>2.3.0</PackageVersion>
+        <PackageVersion>2.4.0</PackageVersion>
         <LangVersion>12</LangVersion>
         <ImplicitUsings>true</ImplicitUsings>
     </PropertyGroup>

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/AmountPerVat.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/AmountPerVat.cs
@@ -1,7 +1,8 @@
 namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
 
+// vat_definition_export_id is an integer up to 9_999_999_999 per spec, so it must be a long.
 public sealed record AmountPerVat(
-    int VatDefinitionExportId,
+    long VatDefinitionExportId,
     decimal GrossAmount,
     decimal NetAmount,
     decimal TaxAmount

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/AmountPerVat.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/AmountPerVat.cs
@@ -1,0 +1,8 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public sealed record AmountPerVat(
+    int VatDefinitionExportId,
+    decimal GrossAmount,
+    decimal NetAmount,
+    decimal TaxAmount
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/BusinessCaseSummary.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/BusinessCaseSummary.cs
@@ -1,0 +1,6 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public sealed record BusinessCaseSummary(
+    BusinessTransactionType Type,
+    IEnumerable<AmountPerVat> AmountsPerVat
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/BusinessTransactionType.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/BusinessTransactionType.cs
@@ -1,0 +1,24 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public enum BusinessTransactionType
+{
+    Umsatz,
+    Pfand,
+    PfandRueckzahlung,
+    Rabatt,
+    Aufschlag,
+    MehrzweckgutscheinKauf,
+    MehrzweckgutscheinEinloesung,
+    EinzweckgutscheinKauf,
+    EinzweckgutscheinEinloesung,
+    Anzahlungseinstellung,
+    Anzahlungsaufloesung,
+    Forderungsentstehung,
+    Forderungsaufloesung,
+    Geldtransit,
+    Einzahlung,
+    Auszahlung,
+    TrinkgeldAG,
+    TrinkgeldAN,
+    DifferenzSollIst
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/BusinessTransactionType.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/BusinessTransactionType.cs
@@ -2,6 +2,7 @@ namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
 
 public enum BusinessTransactionType
 {
+    Anfangsbestand,
     Umsatz,
     Pfand,
     PfandRueckzahlung,
@@ -15,10 +16,15 @@ public enum BusinessTransactionType
     Anzahlungsaufloesung,
     Forderungsentstehung,
     Forderungsaufloesung,
+    Privateinlage,
+    Privatentnahme,
     Geldtransit,
     Einzahlung,
     Auszahlung,
+    Lohnzahlung,
     TrinkgeldAG,
     TrinkgeldAN,
-    DifferenzSollIst
+    ZuschussEcht,
+    ZuschussUnecht,
+    DifferenzSollIst,
 }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/BuyerAddress.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/BuyerAddress.cs
@@ -1,0 +1,9 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+// All fields optional per spec; country_code is ISO 3166-1 alpha-3 (exactly 3 chars).
+public sealed record BuyerAddress(
+    string Street = null,
+    string PostalCode = null,
+    string City = null,
+    string CountryCode = null
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/BuyerType.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/BuyerType.cs
@@ -1,0 +1,7 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public enum BuyerType
+{
+    Customer, // Kunde
+    Employee, // Mitarbeiter
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosing.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosing.cs
@@ -1,0 +1,11 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public sealed record CashPointClosing(
+    Guid ClosingId,
+    Guid ClientId,
+    long CashPointClosingExportId,
+    DateTimeOffset ExportCreationDate,
+    DateOnly BusinessDate,
+    IEnumerable<CashPointClosingTransaction> Transactions,
+    CashStatement CashStatement
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosing.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosing.cs
@@ -6,6 +6,8 @@ public sealed record CashPointClosing(
     long CashPointClosingExportId,
     DateTimeOffset ExportCreationDate,
     DateOnly BusinessDate,
+    string FirstTransactionExportId,
+    string LastTransactionExportId,
     IEnumerable<CashPointClosingTransaction> Transactions,
     CashStatement CashStatement
 );

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingResult.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingResult.cs
@@ -1,0 +1,9 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public sealed record CashPointClosingResult(
+    Guid Id,
+    Guid ClientId,
+    long CashPointClosingExportId,
+    CashPointClosingState State,
+    string Error = null
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingState.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingState.cs
@@ -1,0 +1,10 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public enum CashPointClosingState
+{
+    Pending,
+    Working,
+    Completed,
+    Error,
+    Deleted
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingTransaction.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingTransaction.cs
@@ -14,5 +14,6 @@ public sealed record CashPointClosingTransaction(
     IEnumerable<PaymentTypeAmount> PaymentTypes,
     TransactionSecurity Security,
     Guid? ClosingClientId = null,
-    IEnumerable<TransactionReference> References = null
+    IEnumerable<TransactionReference> References = null,
+    IEnumerable<string> AllocationGroups = null
 );

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingTransaction.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingTransaction.cs
@@ -8,11 +8,11 @@ public sealed record CashPointClosingTransaction(
     DateTimeOffset TimestampEnd,
     bool Storno,
     ProcessType ProcessType,
-    Guid ClosingClientId,
     decimal FullAmountInclVat,
     IEnumerable<TransactionLine> Lines,
     IEnumerable<AmountPerVat> AmountsPerVat,
     IEnumerable<PaymentTypeAmount> PaymentTypes,
     TransactionSecurity Security,
+    Guid? ClosingClientId = null,
     IEnumerable<TransactionReference> References = null
 );

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingTransaction.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingTransaction.cs
@@ -1,0 +1,18 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public sealed record CashPointClosingTransaction(
+    Guid TxId,
+    string TransactionExportId,
+    long Number,
+    DateTimeOffset TimestampStart,
+    DateTimeOffset TimestampEnd,
+    bool Storno,
+    ProcessType ProcessType,
+    Guid ClosingClientId,
+    decimal FullAmountInclVat,
+    IEnumerable<TransactionLine> Lines,
+    IEnumerable<AmountPerVat> AmountsPerVat,
+    IEnumerable<PaymentTypeAmount> PaymentTypes,
+    TransactionSecurity Security,
+    IEnumerable<TransactionReference> References = null
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingTransaction.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingTransaction.cs
@@ -1,7 +1,6 @@
 namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
 
 public sealed record CashPointClosingTransaction(
-    Guid TxId,
     string TransactionExportId,
     long Number,
     DateTimeOffset TimestampStart,
@@ -13,7 +12,14 @@ public sealed record CashPointClosingTransaction(
     IEnumerable<AmountPerVat> AmountsPerVat,
     IEnumerable<PaymentTypeAmount> PaymentTypes,
     TransactionSecurity Security,
+    // Optional per spec: should match the SIGN DE tx_id when one exists, otherwise user-definable.
+    Guid? TxId = null,
+    string Name = null,
+    TransactionUser User = null,
+    TransactionBuyer Buyer = null,
     Guid? ClosingClientId = null,
     IEnumerable<TransactionReference> References = null,
-    IEnumerable<string> AllocationGroups = null
+    IEnumerable<string> AllocationGroups = null,
+    // data.notes
+    string Notes = null
 );

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashStatement.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashStatement.cs
@@ -1,0 +1,6 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public sealed record CashStatement(
+    IEnumerable<BusinessCaseSummary> BusinessCases,
+    CashStatementPayment Payment
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashStatementPayment.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashStatementPayment.cs
@@ -1,0 +1,8 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public sealed record CashStatementPayment(
+    decimal FullAmount,
+    decimal CashAmount,
+    IEnumerable<CurrencyAmount> CashAmountsByCurrency,
+    IEnumerable<PaymentTypeAmount> PaymentTypes
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CurrencyAmount.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CurrencyAmount.cs
@@ -1,0 +1,3 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public sealed record CurrencyAmount(string CurrencyCode, decimal Amount);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/DsfinvkVatDefinition.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/DsfinvkVatDefinition.cs
@@ -1,0 +1,15 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+// DSFinV-K predefined vat_definition_export_id values. The spec fixes ids 1-7, reserves 8-999,
+// and leaves 1000-99999999 for free use, so the wire field stays numeric (long); this enum only
+// names the predefined values so consumers don't hard-code the magic numbers.
+public enum DsfinvkVatDefinition
+{
+    GeneralRate = 1, // 19% Regelsteuersatz
+    ReducedRate = 2, // 7% ermaessigter Steuersatz
+    AverageRateForestrySpecial = 3, // 10.7% Durchschnittssatz (Sec. 24 (1) no. 3 UStG)
+    AverageRateForestryOther = 4, // 5.5% Durchschnittssatz (Sec. 24, remaining cases)
+    NotTaxable = 5, // 0% / nicht steuerbar
+    TaxFree = 6, // umsatzsteuerfrei
+    NotDeterminable = 7, // Umsatzsteuer nicht ermittelbar
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/PaymentType.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/PaymentType.cs
@@ -1,0 +1,15 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+// DSFinV-K payment types (BMF Anhang B "Zahlungsart"). The spec lists "GuthabenKarte" and
+// "Guthabenkarte" as separate strings (a Fiskaly casing quirk); we expose a single VoucherCard
+// and serialize the canonical "Guthabenkarte".
+public enum PaymentType
+{
+    Cash, // Bar
+    NonCash, // Unbar
+    DebitCard, // ECKarte
+    CreditCard, // Kreditkarte
+    ElectronicPaymentServiceProvider, // ElZahlungsdienstleister
+    VoucherCard, // Guthabenkarte
+    None, // Keine
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/PaymentTypeAmount.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/PaymentTypeAmount.cs
@@ -1,7 +1,10 @@
 namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
 
+// ForeignAmount/Name are optional; CurrencyCode is the cash register base currency (required).
 public sealed record PaymentTypeAmount(
     string PaymentType,
     decimal Amount,
-    string CurrencyCode
+    string CurrencyCode,
+    string Name = null,
+    decimal? ForeignAmount = null
 );

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/PaymentTypeAmount.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/PaymentTypeAmount.cs
@@ -2,7 +2,7 @@ namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
 
 // ForeignAmount/Name are optional; CurrencyCode is the cash register base currency (required).
 public sealed record PaymentTypeAmount(
-    string PaymentType,
+    PaymentType PaymentType,
     decimal Amount,
     string CurrencyCode,
     string Name = null,

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/PaymentTypeAmount.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/PaymentTypeAmount.cs
@@ -1,0 +1,7 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public sealed record PaymentTypeAmount(
+    string PaymentType,
+    decimal Amount,
+    string CurrencyCode = null
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/PaymentTypeAmount.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/PaymentTypeAmount.cs
@@ -3,5 +3,5 @@ namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
 public sealed record PaymentTypeAmount(
     string PaymentType,
     decimal Amount,
-    string CurrencyCode = null
+    string CurrencyCode
 );

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/ProcessType.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/ProcessType.cs
@@ -9,6 +9,8 @@ public enum ProcessType
     Training,
     BenefitInKind,
     Invoice,
-    Other
-    // ANNULATION is intentionally excluded: Fiskaly forbids it for TSS-connected systems (§7.4)
+    Other,
+    // The spec value "AVBelegabbruch" (document abort) is intentionally omitted: Fiskaly forbids
+    // it for TSS-connected systems (§7.4), so exposing it would let a caller build a payload that
+    // Fiskaly rejects. Add it here only if a non-TSS integration ever needs it.
 }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/ProcessType.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/ProcessType.cs
@@ -1,0 +1,14 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public enum ProcessType
+{
+    Receipt,
+    Transfer,
+    Order,
+    Cancellation,
+    Training,
+    BenefitInKind,
+    Invoice,
+    Other
+    // ANNULATION is intentionally excluded: Fiskaly forbids it for TSS-connected systems (§7.4)
+}

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionBuyer.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionBuyer.cs
@@ -1,0 +1,10 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+// Buyer information (head.buyer). Name, BuyerExportId and Type are required by the spec.
+public sealed record TransactionBuyer(
+    string Name,
+    string BuyerExportId,
+    BuyerType Type,
+    BuyerAddress Address = null,
+    string VatIdNumber = null
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionLine.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionLine.cs
@@ -6,12 +6,28 @@ public sealed record TransactionLine(
     BusinessTransactionType BusinessTransactionType,
     IEnumerable<AmountPerVat> BusinessCaseAmountsPerVat,
     string ItemText,
-    TransactionLineItem Item = null
+    TransactionLineItem Item = null,
+    string BusinessCaseName = null,
+    Guid? PurchaserAgencyId = null,
+    // in_house defaults to true on the Fiskaly side; leave null to omit.
+    bool? InHouse = null,
+    string VoucherId = null,
+    Guid? SourceCashRegister = null,
+    IEnumerable<TransactionReference> References = null
 );
 
 // DSFinV-K line `item` (optional). number/quantity/price_per_unit are required when item is present.
 public sealed record TransactionLineItem(
     string Number,
     decimal Quantity,
-    decimal PricePerUnit
+    decimal PricePerUnit,
+    string Gtin = null,
+    decimal? QuantityFactor = null,
+    string QuantityMeasure = null,
+    string GroupId = null,
+    string GroupName = null,
+    IEnumerable<VatAmountBreakdown> BaseAmountsPerVat = null,
+    IEnumerable<VatAmountBreakdown> DiscountsPerVat = null,
+    IEnumerable<VatAmountBreakdown> ExtraAmountsPerVat = null,
+    IEnumerable<TransactionSubItem> SubItems = null
 );

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionLine.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionLine.cs
@@ -1,0 +1,13 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public sealed record TransactionLine(
+    string LineItemExportId,
+    bool Storno,
+    BusinessTransactionType BusinessTransactionType,
+    IEnumerable<AmountPerVat> BusinessCaseAmountsPerVat,
+    string ItemText,
+    decimal Quantity,
+    decimal PricePerUnit,
+    decimal GrossAmount,
+    decimal NetAmount
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionLine.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionLine.cs
@@ -6,8 +6,12 @@ public sealed record TransactionLine(
     BusinessTransactionType BusinessTransactionType,
     IEnumerable<AmountPerVat> BusinessCaseAmountsPerVat,
     string ItemText,
+    TransactionLineItem Item = null
+);
+
+// DSFinV-K line `item` (optional). number/quantity/price_per_unit are required when item is present.
+public sealed record TransactionLineItem(
+    string Number,
     decimal Quantity,
-    decimal PricePerUnit,
-    decimal GrossAmount,
-    decimal NetAmount
+    decimal PricePerUnit
 );

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionReference.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionReference.cs
@@ -1,7 +1,26 @@
 namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
 
-// Fiskaly v1 only supports type "InterneTransaktion" for TSS-connected systems; the library maps it unconditionally.
+public enum ReferenceType
+{
+    InternalTransaction,   // InterneTransaktion
+    Transaction,           // Transaktion
+    ExternalBill,          // ExterneRechnung
+    ExternalDeliveryNote,  // ExternerLieferschein
+    ExternalOther          // ExterneSonstige
+}
+
+// Polymorphic DSFinV-K reference; only the fields of the chosen Type are sent.
+// Required per type: InternalTransaction -> TxId; Transaction -> CashPointClosingExportId,
+// CashRegisterExportId, TransactionExportId; ExternalBill/ExternalDeliveryNote -> ExternalExportId;
+// ExternalOther -> ExternalOtherExportId, Name. Date is optional everywhere.
 public sealed record TransactionReference(
-    Guid? TxId,
-    Guid? ClosingId
+    ReferenceType Type,
+    Guid? TxId = null,
+    long? CashPointClosingExportId = null,
+    string CashRegisterExportId = null,
+    string TransactionExportId = null,
+    string ExternalExportId = null,
+    string ExternalOtherExportId = null,
+    string Name = null,
+    DateTimeOffset? Date = null
 );

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionReference.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionReference.cs
@@ -1,0 +1,7 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+// Fiskaly v1 only supports type "InterneTransaktion" for TSS-connected systems; the library maps it unconditionally.
+public sealed record TransactionReference(
+    Guid? TxId,
+    Guid? ClosingId
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionSecurity.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionSecurity.cs
@@ -1,0 +1,6 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+public sealed record TransactionSecurity(
+    Guid? TssTxId,
+    string ErrorMessage = null
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionSubItem.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionSubItem.cs
@@ -1,0 +1,15 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+// Explains the composition of a sold product (e.g. a menu split into its parts).
+// Number, Quantity and AmountPerVat are required when a sub-item is present.
+public sealed record TransactionSubItem(
+    string Number,
+    decimal Quantity,
+    VatAmountBreakdown AmountPerVat,
+    string Gtin = null,
+    string Name = null,
+    decimal? QuantityFactor = null,
+    string QuantityMeasure = null,
+    string GroupId = null,
+    string GroupName = null
+);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionUser.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/TransactionUser.cs
@@ -1,0 +1,4 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+// Person who recorded the transaction at the cash register (head.user).
+public sealed record TransactionUser(string UserExportId, string Name = null);

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/VatAmountBreakdown.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/VatAmountBreakdown.cs
@@ -1,0 +1,10 @@
+namespace Mews.Fiscalizations.Fiskaly.Models.DSFinVK.CashPointClosings;
+
+// Per-VAT amount breakdown for item base/discount/extra amounts and sub-items.
+// The spec accepts {ExclVat + Vat}, {InclVat}, or all three; send the combination that applies.
+public sealed record VatAmountBreakdown(
+    long VatDefinitionExportId,
+    decimal? InclVat = null,
+    decimal? ExclVat = null,
+    decimal? Vat = null
+);

--- a/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
+++ b/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>37.3.0</PackageVersion>
+    <PackageVersion>37.4.0</PackageVersion>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>


### PR DESCRIPTION
## Release note
https://mews.atlassian.net/browse/EXP-4394: Add DSFinV-K Cash Point Closing support (insert / get / delete) to the Fiskaly client, validated against the live Fiskaly API.

---

## Summary
- Adds Cash Point Closing to `DsfinvkApiClient`: `InsertCashPointClosingAsync` (idempotent `PUT cash_point_closings/{closingId}`), `GetCashPointClosingAsync`, `DeleteCashPointClosingAsync`, plus the payload models, DTOs and mapper.
- Payload was validated end-to-end against the live Fiskaly DSFinV-K API. The original service implementation was never integration-tested and used field names the API rejects; corrected to the DSFinV-K taxonomy: `incl_vat`/`excl_vat`/`vat` (was gross/net/tax), payment `type` (was payment_type), line `text` (was item_text), BON_TYP `Beleg`/`AVRechnung`/`AVTransfer`/... (was RECEIPT/INVOICE/...), and added the required `timestamp_start`/`timestamp_end`, `full_amount_incl_vat`, `lineitem_export_id` and per-line `storno`.
- Response mapping aligned to `closing_id` and the `DELETED` state.
- Removes the `Assert.Ignore` skip-guards from the DSFinV-K tests so they always run.
- Bumps package versions: `Mews.Fiscalizations.Fiskaly` 2.3.0 -> 2.4.0, `Mews.Fiscalizations.All` 37.3.0 -> 37.4.0.

---

## Testing steps
- Set `fiskaly_dsfinvk_api_key`, `fiskaly_dsfinvk_api_secret`, `fiskaly_dsfinvk_test_client_id`, `fiskaly_dsfinvk_test_tss_id` and run the `DSFinVK` test category.
- All 6 DSFinV-K tests (Auth, CashRegister x2, CashPointClosing x3) pass against the live Fiskaly test environment on net8.0 and net10.0.

---

## Test coverage
Insert/Get/Delete cash point closing are covered by live integration tests. The skip-guards were removed so the suite runs in CI (requires the four FISKALY_DSFINVK_* secrets to be configured).

---

## Feature flag
N/A at the library level (consumed by the monolith behind the dsfinvkEnabled flag).

---

## Critical User Journeys / Golden Paths
N/A — additive library surface; not yet wired into a production flow.

---

## Database changes
N/A.

---

## Performance & Security & Data Privacy
- Observability: errors surface as `ResponseResult.ErrorResult` to the caller.
- Blast radius: additive only; existing SignES/Management/cash-register clients untouched.
- Rollback: revert the version bump / do not consume 37.4.0.

---

## Follow-up issues
- CI needs the `FISKALY_DSFINVK_*` repository secrets created for the tests to pass.
- Monolith closing builder (later EXP tickets) must populate the new required fields (timestamps, full_amount_incl_vat, lineitem_export_id, line storno).