### PR TITLE
Revert: decode HTML entities in AEAT SOAP response (#314)

### DIFF
--- a/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
+++ b/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>37.4.0</PackageVersion>
+    <PackageVersion>37.4.1</PackageVersion>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>

--- a/src/Spain/Mews.Fiscalizations.Spain/Communication/SoapClient.cs
+++ b/src/Spain/Mews.Fiscalizations.Spain/Communication/SoapClient.cs
@@ -1,8 +1,7 @@
-using Mews.Fiscalizations.Core.Xml;
+﻿using Mews.Fiscalizations.Core.Xml;
 using Mews.Fiscalizations.Spain.Dto.Responses.SoapFault;
 using Mews.Fiscalizations.Spain.Model.Response;
 using System.Diagnostics;
-using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Xml;
@@ -75,8 +74,7 @@ internal class SoapClient
     private XmlElement GetSoapBody(string soapXmlString)
     {
         var xmlDocument = new XmlDocument();
-        var decodedXml = WebUtility.HtmlDecode(soapXmlString);
-        xmlDocument.LoadXml(decodedXml);
+        xmlDocument.LoadXml(soapXmlString);
 
         var soapMessage = SoapMessage.FromSoapXml(xmlDocument);
         return soapMessage.Body.FirstChild as XmlElement;

--- a/src/Spain/Mews.Fiscalizations.Spain/Mews.Fiscalizations.Spain.csproj
+++ b/src/Spain/Mews.Fiscalizations.Spain/Mews.Fiscalizations.Spain.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>12.0.5</PackageVersion>
+    <PackageVersion>12.0.6</PackageVersion>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
## What

Reverts #314.

## Why

The `WebUtility.HtmlDecode` fix only covered HTML named entities like `&oacute;`, but the AEAT SOAP response can also contain malformed XML that `HtmlDecode` does not handle — specifically, bare `&` characters that do not form a valid entity name. This triggers a different `XmlException` (`An error occurred while parsing EntityName`) that the fix does not address.

Sentry errors still occurring after the fix was deployed:
- BILLING-BE-39X
- BILLING-BE-39Y

A more comprehensive fix is needed.