### PR TITLE
EXP-4396: make CashPointClosing transaction lines optional (37.4.2)

### DIFF
--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
@@ -85,7 +85,7 @@ internal static class CashPointClosingMapper
             Data = new TransactionDataDto
             {
                 FullAmountInclVat = tx.FullAmountInclVat,
-                Lines = tx.Lines.Select(MapLine).ToList(),
+                Lines = tx.Lines?.Select(MapLine).ToList(),
                 AmountsPerVatId = tx.AmountsPerVat.Select(MapAmountPerVat).ToList(),
                 PaymentTypes = tx.PaymentTypes.Select(MapPaymentType).ToList(),
                 Notes = tx.Notes,

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingTransaction.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Models/DSFinVK/CashPointClosings/CashPointClosingTransaction.cs
@@ -8,7 +8,6 @@ public sealed record CashPointClosingTransaction(
     bool Storno,
     ProcessType ProcessType,
     decimal FullAmountInclVat,
-    IEnumerable<TransactionLine> Lines,
     IEnumerable<AmountPerVat> AmountsPerVat,
     IEnumerable<PaymentTypeAmount> PaymentTypes,
     TransactionSecurity Security,
@@ -18,6 +17,8 @@ public sealed record CashPointClosingTransaction(
     TransactionUser User = null,
     TransactionBuyer Buyer = null,
     Guid? ClosingClientId = null,
+    // Optional per spec (data.lines): per-position detail. Omit (null) to report at aggregate level only.
+    IEnumerable<TransactionLine> Lines = null,
     IEnumerable<TransactionReference> References = null,
     IEnumerable<string> AllocationGroups = null,
     // data.notes

--- a/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
+++ b/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>37.4.1</PackageVersion>
+    <PackageVersion>37.4.2</PackageVersion>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>


### PR DESCRIPTION
## Summary
- `data.lines` is optional per the DSFinV-K spec (only `full_amount_incl_vat` is required in `data`). Default `CashPointClosingTransaction.Lines` to `null` and make the mapper null-safe, so a caller can report a closing at aggregate level (`amounts_per_vat` + `cash_statement`) without emitting per-position line items.
- Bumps `Mews.Fiscalizations.All` to `37.4.2`.

## Motivation
The monolith DSFinV-K closing builder (EXP-4396) reports closings at aggregate level for v1 and does not send per-position lines. Without this, omitting lines would NPE in the mapper.

## Testing
- Library + tests build clean.
- Live `CashPointClosingTests` exercise the PUT/GET against Fiskaly in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)