### PR TITLE
EXP-4396: support DSFinV-K cash point closing without transactions

### DIFF
--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashPointClosingTests.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashPointClosingTests.cs
@@ -56,8 +56,6 @@ public class CashPointClosingTests
     [Test]
     public async Task InsertCashPointClosingWithoutTransactionsSucceeds()
     {
-        // DSFinV-K allows a closing without transactions: cash_statement and transactions are omitted
-        // and the head transaction ids are null. See fiskaly docs (insertCashPointClosing).
         var closing = BuildEmptyTestClosing(exportId: Math.Abs(Guid.NewGuid().GetHashCode()));
         var result = await _client.InsertCashPointClosingAsync(_accessToken, closing);
 

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashPointClosingTests.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly.Tests/DSFinVK/CashPointClosingTests.cs
@@ -54,6 +54,28 @@ public class CashPointClosingTests
     }
 
     [Test]
+    public async Task InsertCashPointClosingWithoutTransactionsSucceeds()
+    {
+        // DSFinV-K allows a closing without transactions: cash_statement and transactions are omitted
+        // and the head transaction ids are null. See fiskaly docs (insertCashPointClosing).
+        var closing = BuildEmptyTestClosing(exportId: Math.Abs(Guid.NewGuid().GetHashCode()));
+        var result = await _client.InsertCashPointClosingAsync(_accessToken, closing);
+
+        Assert.That(
+            result.IsSuccess,
+            $"[{result.ErrorResult?.Status}] {result.ErrorResult?.Error} :: {result.ErrorResult?.Message}"
+        );
+        Assert.That(
+            result.SuccessResult.State,
+            Is.AnyOf(
+                CashPointClosingState.Pending,
+                CashPointClosingState.Working,
+                CashPointClosingState.Completed
+            )
+        );
+    }
+
+    [Test]
     public async Task GetCashPointClosingSucceeds()
     {
         Assert.That(
@@ -96,6 +118,21 @@ public class CashPointClosingTests
             SoftwareBrand: "Mews",
             SoftwareVersion: "1.0.0",
             BaseCurrencyCode: "EUR"
+        );
+    }
+
+    private static CashPointClosing BuildEmptyTestClosing(long exportId)
+    {
+        return new CashPointClosing(
+            ClosingId: Guid.NewGuid(),
+            ClientId: TestFixture.DsfinvkTestClientId,
+            CashPointClosingExportId: exportId,
+            ExportCreationDate: DateTimeOffset.UtcNow,
+            BusinessDate: DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)),
+            FirstTransactionExportId: null,
+            LastTransactionExportId: null,
+            Transactions: Array.Empty<CashPointClosingTransaction>(),
+            CashStatement: null
         );
     }
 

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
@@ -29,9 +29,6 @@ internal sealed class CashPointClosingHead
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string BusinessDate { get; init; }
 
-    // DSFinV-K expects these keys present even on a zero-transaction day, where both are null.
-    // JsonIgnoreCondition.Never overrides the serializer's global WhenWritingNull default so the
-    // null values are written explicitly rather than dropped.
     [JsonPropertyName("first_transaction_export_id")]
     [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public string FirstTransactionExportId { get; init; }

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/DTOs/DSFinVK/CashPointClosings/InsertCashPointClosingRequest.cs
@@ -29,11 +29,15 @@ internal sealed class CashPointClosingHead
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string BusinessDate { get; init; }
 
-    // Required by the spec (the caller sends "0" on zero-transaction days).
+    // DSFinV-K expects these keys present even on a zero-transaction day, where both are null.
+    // JsonIgnoreCondition.Never overrides the serializer's global WhenWritingNull default so the
+    // null values are written explicitly rather than dropped.
     [JsonPropertyName("first_transaction_export_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public string FirstTransactionExportId { get; init; }
 
     [JsonPropertyName("last_transaction_export_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public string LastTransactionExportId { get; init; }
 }
 

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
@@ -44,13 +44,9 @@ internal static class CashPointClosingMapper
                     "yyyy-MM-dd",
                     CultureInfo.InvariantCulture
                 ),
-                // DSFinV-K: a day without transactions has no first/last transaction, so both ids are
-                // sent explicitly as null (the head DTO forces them past the WhenWritingNull default).
                 FirstTransactionExportId = hasTransactions ? closing.FirstTransactionExportId : null,
                 LastTransactionExportId = hasTransactions ? closing.LastTransactionExportId : null,
             },
-            // DSFinV-K: transactions and cash_statement are "not to be used" on a day without
-            // transactions, so they are omitted entirely (null is dropped by WhenWritingNull).
             Transactions = hasTransactions ? transactions.Select(MapTransaction).ToList() : null,
             CashStatement = hasTransactions ? MapCashStatement(closing.CashStatement) : null,
         };

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mappers/DSFinVK/CashPointClosings/CashPointClosingMapper.cs
@@ -30,7 +30,8 @@ internal static class CashPointClosingMapper
 {
     public static InsertCashPointClosingRequestDto MapInsertRequest(CashPointClosing closing)
     {
-        var transactions = closing.Transactions.ToList();
+        var transactions = closing.Transactions?.ToList() ?? new List<CashPointClosingTransaction>();
+        var hasTransactions = transactions.Count > 0;
 
         return new InsertCashPointClosingRequestDto
         {
@@ -43,11 +44,15 @@ internal static class CashPointClosingMapper
                     "yyyy-MM-dd",
                     CultureInfo.InvariantCulture
                 ),
-                FirstTransactionExportId = closing.FirstTransactionExportId,
-                LastTransactionExportId = closing.LastTransactionExportId,
+                // DSFinV-K: a day without transactions has no first/last transaction, so both ids are
+                // sent explicitly as null (the head DTO forces them past the WhenWritingNull default).
+                FirstTransactionExportId = hasTransactions ? closing.FirstTransactionExportId : null,
+                LastTransactionExportId = hasTransactions ? closing.LastTransactionExportId : null,
             },
-            Transactions = transactions.Select(MapTransaction).ToList(),
-            CashStatement = MapCashStatement(closing.CashStatement),
+            // DSFinV-K: transactions and cash_statement are "not to be used" on a day without
+            // transactions, so they are omitted entirely (null is dropped by WhenWritingNull).
+            Transactions = hasTransactions ? transactions.Select(MapTransaction).ToList() : null,
+            CashStatement = hasTransactions ? MapCashStatement(closing.CashStatement) : null,
         };
     }
 

--- a/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mews.Fiscalizations.Fiskaly.csproj
+++ b/src/Fiskaly/Mews.Fiscalizations.Fiskaly/Mews.Fiscalizations.Fiskaly.csproj
@@ -9,7 +9,7 @@
         <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
         <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <PackageVersion>2.4.0</PackageVersion>
+        <PackageVersion>2.5.0</PackageVersion>
         <LangVersion>12</LangVersion>
         <ImplicitUsings>true</ImplicitUsings>
     </PropertyGroup>

--- a/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
+++ b/src/Mews.Fiscalizations.All/Mews.Fiscalizations.All.csproj
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/MewsSystems/fiscalizations</RepositoryUrl>
     <Icon>https://raw.githubusercontent.com/msigut/eet/master/receipt.png</Icon>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>38.0.0</PackageVersion>
+    <PackageVersion>38.1.0</PackageVersion>
     <LangVersion>12</LangVersion>
     <ImplicitUsings>true</ImplicitUsings>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>


### PR DESCRIPTION
## What

Adds support for submitting a DSFinV-K `cashPointClosing` for a day **without transactions**.

Per the [fiskaly DSFinV-K API](https://developer.fiskaly.com/api/dsfinvk/v1#operation/insertCashPointClosing), on a day without transactions the `transactions` and `cash_statement` objects are no longer required and **must not be used**, and the head's `first/last_transaction_export_id` are `null`:

```json
{
  "head": {
    "first_transaction_export_id": null,
    "last_transaction_export_id": null,
    "export_creation_date": 1700000000
  },
  "client_id": "…",
  "cash_point_closing_export_id": 123
}
```

## Changes

- **`CashPointClosingMapper`** — when the closing has no transactions, emit `null` head ids and drop `transactions` + `cash_statement` (null is omitted by the serializer's `WhenWritingNull` default). Also tolerates a null `Transactions` collection.
- **`InsertCashPointClosingRequest`** — `first/last_transaction_export_id` now carry `[JsonIgnore(Condition = Never)]` so they serialize **explicitly as `null`** instead of being dropped by the global `WhenWritingNull` default.
- **Test** — new integration test `InsertCashPointClosingWithoutTransactionsSucceeds`.
- **Versions** — Fiskaly `2.4.0 → 2.5.0`, All `38.0.0 → 38.1.0`.

## Notes

The branching is done in the mapper, so the correct wire format is produced regardless of what a caller passes for the empty-day case (no consumer change required to get the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
